### PR TITLE
feat: add initial server that can mint tokens on demand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,11 +42,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "authority-service"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
+ "clap",
+ "config",
+ "hex",
  "nillion-nucs",
+ "rand",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -191,6 +272,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "config"
+version = "0.15.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb07d21d12f9f0bc5e7c3e97ccc78b2341b9b4a4604eac3ed7c1d0d6e2c3b23e"
+dependencies = [
+ "pathdiff",
+ "serde",
+ "winnow",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +508,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "form_urlencoded"
@@ -453,6 +607,24 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -605,6 +777,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +838,15 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchit"
@@ -690,7 +883,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -741,6 +934,12 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -832,6 +1031,50 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rfc6979"
@@ -971,6 +1214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1062,6 +1314,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,7 +1366,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1154,7 +1416,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1164,6 +1438,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1177,6 +1466,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -1273,6 +1568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1639,26 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232bdb534d65520716bef0bbb205ff8f2db72d807b19c0bc3020853b92a0cd4b"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "hex",
  "nillion-nucs",
  "rand",
+ "rstest",
  "serde",
  "serde_json",
  "tokio",
@@ -584,6 +585,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"
@@ -1077,6 +1084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,10 +1100,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustversion"
@@ -1117,6 +1166,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ tokio = { version = "1.43", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 rand = "0.8"
+rstest = { version = "0.25", default-features = false }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0"
 axum = "0.8"
+clap = { version = "4.5", features = ["derive", "env"] }
+config = { version = "0.15", default-features = false, features = ["yaml"] }
+hex = { version = "0.4", features = ["serde"] }
 nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "c74c73754a2eaad41a12555bf5f694a341e3796f" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros"] }
 
+[dev-dependencies]
+rand = "0.8"

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,0 +1,5 @@
+server:
+  bind_endpoint: 127.0.0.1:30921
+
+private_key:
+  hex: 7c5c8d3114ac2410249ca2baae7dec86ac2950a389ac44a5fdca8941b92b6c86

--- a/scripts/create-nuc.py
+++ b/scripts/create-nuc.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = [
+#   "requests==2.32.3",
+#   "secp256k1==0.14.0",
+# ]
+# ///
+
+
+import json
+import requests
+import secrets
+from secp256k1 import PrivateKey
+
+
+if __name__ == "__main__":
+    key = PrivateKey()
+    payload = json.dumps(
+        {
+            "nonce": list(secrets.token_bytes(16)),
+        }
+    ).encode("utf8")
+    signature = key.ecdsa_serialize_compact(key.ecdsa_sign(payload))
+    request = {
+        "public_key": key.pubkey.serialize(True).hex(),
+        "signature": signature.hex(),
+        "payload": payload.hex(),
+    }
+    response = requests.post("http://127.0.0.1:30921/api/v1/nucs/create", json=request)
+    response.raise_for_status()
+    response = response.json()
+    print(json.dumps(response))

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,20 @@
+use clap::Parser;
+
+/// Nillion authority service.
+#[derive(Parser)]
+pub struct Cli {
+    /// The path to the config file.
+    #[clap(short, long)]
+    pub config_file: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_cli() {
+        Cli::command().debug_assert();
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,59 @@
+use anyhow::Context;
+use nillion_nucs::k256::SecretKey;
+use serde::Deserialize;
+use std::{fs, net::SocketAddr, path::PathBuf};
+
+/// The configuration for the authority service.
+#[derive(Deserialize)]
+pub struct Config {
+    /// The server configuration.
+    pub server: ServerConfig,
+
+    /// The private key
+    pub private_key: PrivateKeyConfig,
+}
+
+impl Config {
+    pub fn load(path: Option<&str>) -> anyhow::Result<Self> {
+        let mut builder = config::Config::builder()
+            .add_source(config::Environment::with_prefix("AUTHORITY").separator("__"));
+        if let Some(path) = path {
+            builder = builder.add_source(config::File::new(path, config::FileFormat::Yaml));
+        }
+        let config = builder.build()?;
+        let config = config.try_deserialize()?;
+        Ok(config)
+    }
+}
+
+/// The server configuration.
+#[derive(Deserialize)]
+pub struct ServerConfig {
+    /// The endpoint to bind to.
+    pub bind_endpoint: SocketAddr,
+}
+
+/// The secp256k1 private key to use.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrivateKeyConfig {
+    /// The raw private key in hex.
+    Hex(#[serde(deserialize_with = "hex::serde::deserialize")] [u8; 32]),
+
+    /// The path to the private key.
+    Path(PathBuf),
+}
+
+impl PrivateKeyConfig {
+    /// Load a key using this configuration.
+    pub fn load_key(&self) -> anyhow::Result<SecretKey> {
+        let bytes = match self {
+            PrivateKeyConfig::Hex(bytes) => bytes.to_vec(),
+            PrivateKeyConfig::Path(path_buf) => {
+                fs::read(path_buf).context("failed to read private key from file")?
+            }
+        };
+        let private_key = SecretKey::from_slice(&bytes).context("invalid private key")?;
+        Ok(private_key)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,1 +1,41 @@
-fn main() {}
+use anyhow::Context;
+use args::Cli;
+use clap::Parser;
+use config::Config;
+use state::AppState;
+use std::process::exit;
+use tokio::net::TcpListener;
+use tracing::info;
+
+mod args;
+mod config;
+mod routes;
+mod state;
+
+async fn run(cli: Cli) -> anyhow::Result<()> {
+    let config = Config::load(cli.config_file.as_deref())?;
+    let secret_key = config.private_key.load_key()?;
+    let state = AppState { secret_key };
+    let router = routes::build_router(state);
+    info!("Starting server on {}", config.server.bind_endpoint);
+    let listener = TcpListener::bind(config.server.bind_endpoint)
+        .await
+        .context("failed to bind to endpoint")?;
+    axum::serve(listener, router)
+        .await
+        .context("failed to run application")?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().init();
+
+    let cli = Cli::parse();
+    if let Err(e) = run(cli).await {
+        eprintln!("Failed to run server: {e}");
+        exit(1);
+    } else {
+        Ok(())
+    }
+}

--- a/src/routes/about.rs
+++ b/src/routes/about.rs
@@ -1,0 +1,16 @@
+use crate::state::SharedState;
+use axum::Json;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub(crate) struct About {
+    #[serde(serialize_with = "hex::serde::serialize")]
+    public_key: Box<[u8]>,
+}
+
+pub(crate) async fn handler(state: SharedState) -> Json<About> {
+    About {
+        public_key: state.0.secret_key.public_key().to_sec1_bytes(),
+    }
+    .into()
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,0 +1,17 @@
+use crate::state::AppState;
+use axum::{
+    routing::{get, post},
+    Router,
+};
+use std::sync::Arc;
+
+pub(crate) mod about;
+pub(crate) mod nucs;
+
+pub fn build_router(state: AppState) -> Router {
+    let state = Arc::new(state);
+    Router::new()
+        .route("/about", get(about::handler))
+        .route("/api/v1/nucs/create", post(nucs::create::handler))
+        .with_state(state)
+}

--- a/src/routes/nucs/create.rs
+++ b/src/routes/nucs/create.rs
@@ -1,0 +1,134 @@
+use crate::state::SharedState;
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use nillion_nucs::k256::ecdsa::{signature::Verifier, Signature};
+use nillion_nucs::{builder::NucTokenBuilder, k256::ecdsa::VerifyingKey, token::Did};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info};
+
+#[derive(Deserialize)]
+pub(crate) struct CreateNucRequest {
+    #[serde(deserialize_with = "hex::serde::deserialize")]
+    public_key: [u8; 33],
+
+    #[serde(deserialize_with = "hex::serde::deserialize")]
+    signature: [u8; 64],
+
+    #[serde(deserialize_with = "hex::serde::deserialize")]
+    payload: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SignablePayload {
+    #[allow(dead_code)]
+    nonce: [u8; 16],
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CreateNucResponse {
+    token: String,
+}
+
+pub(crate) async fn handler(
+    state: SharedState,
+    request: Json<CreateNucRequest>,
+) -> Result<Json<CreateNucResponse>, Response> {
+    let request = request.0;
+    // Validate the payload has the right shape and toss it away.
+    serde_json::from_slice::<SignablePayload>(&request.payload)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid payload: {e}")).into_response())?;
+
+    let verifying_key = VerifyingKey::from_sec1_bytes(&request.public_key)
+        .map_err(|_| (StatusCode::BAD_REQUEST, "invalid public key").into_response())?;
+    let signature = Signature::from_bytes(&request.signature.into())
+        .map_err(|_| (StatusCode::BAD_REQUEST, "invalid signature").into_response())?;
+    verifying_key
+        .verify(&request.payload, &signature)
+        .map_err(|_| (StatusCode::BAD_REQUEST, "signature verification failed").into_response())?;
+
+    let requestor_did = Did::nil(request.public_key);
+    info!("Minting token for {requestor_did}");
+    let token = NucTokenBuilder::delegation([])
+        .command(["nil"])
+        .subject(requestor_did.clone())
+        .audience(requestor_did)
+        .build(&state.secret_key.clone().into())
+        .map_err(|e| {
+            error!("Failed to sign token: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        })?;
+    let response = CreateNucResponse { token };
+    Ok(Json(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use axum::extract::State;
+    use nillion_nucs::{
+        envelope::NucTokenEnvelope,
+        k256::{
+            ecdsa::{signature::Signer, SigningKey},
+            SecretKey,
+        },
+    };
+    use std::{ops::Deref, sync::Arc};
+
+    #[tokio::test]
+    async fn valid_request() {
+        let server_key = SecretKey::random(&mut rand::thread_rng());
+        let state = Arc::new(AppState {
+            secret_key: server_key.clone(),
+        });
+
+        let client_key = SecretKey::random(&mut rand::thread_rng());
+        let payload = serde_json::to_string(&SignablePayload { nonce: [0; 16] }).unwrap();
+        let signature: Signature = SigningKey::from(client_key.clone()).sign(payload.as_bytes());
+        let signature = signature.to_bytes().try_into().unwrap();
+        let request = CreateNucRequest {
+            public_key: client_key
+                .public_key()
+                .to_sec1_bytes()
+                .deref()
+                .try_into()
+                .unwrap(),
+            signature,
+            payload: payload.as_bytes().to_vec(),
+        };
+        let response = handler(State(state), Json(request))
+            .await
+            .expect("failed to mint token");
+        NucTokenEnvelope::decode(&response.token)
+            .expect("invalid token")
+            .validate_signatures()
+            .expect("invalid signatures");
+    }
+
+    #[tokio::test]
+    async fn invalid_signature() {
+        let server_key = SecretKey::random(&mut rand::thread_rng());
+        let state = Arc::new(AppState {
+            secret_key: server_key.clone(),
+        });
+
+        let payload = serde_json::to_string(&SignablePayload { nonce: [0; 16] }).unwrap();
+        let public_key =
+            hex::decode("03ef993b7e986d25f7cfcd2ec75e752d3c364c2080df6f0d31fe7f58e5bf9a66a5")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let request = CreateNucRequest {
+            public_key,
+            signature: [0xab; 64],
+            payload: payload.as_bytes().to_vec(),
+        };
+        handler(State(state), Json(request))
+            .await
+            .expect_err("token was minted");
+    }
+}

--- a/src/routes/nucs/mod.rs
+++ b/src/routes/nucs/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod create;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,11 @@
+use axum::extract::State;
+use nillion_nucs::k256::SecretKey;
+use std::sync::Arc;
+
+pub(crate) type SharedState = State<Arc<AppState>>;
+
+/// The state to be shared across all routes.
+pub struct AppState {
+    /// The server's secret key.
+    pub secret_key: SecretKey,
+}


### PR DESCRIPTION
This adds an initial server that has 2 endpoints:

* `/about` that returns the server's public key.
* `/api/v1/nucs/create` that takes a signed payload and returns a signed token.

This includes a python script that allows invoking the `create` endpoint as an example of how to use it. Things like metrics will be added in subsequent PRs.