### PR TITLE
chore: use hex when serializing signable payload

### DIFF
--- a/src/routes/nucs/create.rs
+++ b/src/routes/nucs/create.rs
@@ -26,6 +26,10 @@ pub(crate) struct CreateNucRequest {
 #[serde(deny_unknown_fields)]
 struct SignablePayload {
     #[allow(dead_code)]
+    #[serde(
+        serialize_with = "hex::serde::serialize",
+        deserialize_with = "hex::serde::deserialize"
+    )]
     nonce: [u8; 16],
 }
 


### PR DESCRIPTION
This changes the payload to be hex since we're using hex everywhere to represent `Vec<u8>`