### PR TITLE
feat: validate subscription when minting tokens

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -4,9 +4,6 @@ server:
 private_key:
   hex: 7c5c8d3114ac2410249ca2baae7dec86ac2950a389ac44a5fdca8941b92b6c86
 
-tokens:
-  expiration_seconds: 3024000
-
 metrics:
   bind_endpoint: 127.0.0.1:39022
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,16 +5,13 @@ use serde_with::serde_as;
 use std::{fs, net::SocketAddr, path::PathBuf, time::Duration};
 
 /// The configuration for the authority service.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct Config {
     /// The server configuration.
     pub server: ServerConfig,
 
     /// The private key
     pub private_key: PrivateKeyConfig,
-
-    /// Configuration for tokens.
-    pub tokens: TokensConfig,
 
     /// Configuration for metrics.
     pub metrics: MetricsConfig,
@@ -40,14 +37,14 @@ impl Config {
 }
 
 /// The server configuration.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct ServerConfig {
     /// The endpoint to bind to.
     pub bind_endpoint: SocketAddr,
 }
 
 /// The secp256k1 private key to use.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PrivateKeyConfig {
     /// The raw private key in hex.
@@ -71,23 +68,15 @@ impl PrivateKeyConfig {
     }
 }
 
-/// The configuration for minted tokens.
-#[derive(Deserialize)]
-pub struct TokensConfig {
-    /// The token expiration in seconds.
-    #[serde(rename = "expiration_seconds")]
-    pub expiration: u64,
-}
-
 /// The configuration for metrics.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct MetricsConfig {
     /// The address to bind to.
     pub bind_endpoint: SocketAddr,
 }
 
 /// The payments configuration.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct PaymentsConfig {
     /// The nilchain RPC URL to use.
     pub nilchain_url: String,
@@ -98,7 +87,7 @@ pub struct PaymentsConfig {
 
 /// The subscription configuration.
 #[serde_as]
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct SubscriptionConfig {
     /// The minimum time needed for a subscription to be renewed.
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
@@ -112,7 +101,7 @@ pub struct SubscriptionConfig {
 }
 
 /// The postgres configuration.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct PostgresConfig {
     /// The connection string to use.
     pub url: String,

--- a/src/db/account.rs
+++ b/src/db/account.rs
@@ -11,17 +11,19 @@ use tracing::{error, info};
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait AccountDb: Send + Sync + 'static {
+    async fn find_subscription_end(
+        &self,
+        public_key: &PublicKey,
+    ) -> sqlx::Result<Option<DateTime<Utc>>>;
+
     async fn credit_payment(
         &self,
         tx_hash: &str,
         public_key: PublicKey,
     ) -> Result<(), CreditPaymentError>;
 
-    async fn store_invalid_payment(
-        &self,
-        tx_hash: &str,
-        public_key: PublicKey,
-    ) -> Result<(), sqlx::Error>;
+    async fn store_invalid_payment(&self, tx_hash: &str, public_key: PublicKey)
+        -> sqlx::Result<()>;
 }
 
 pub struct PostgresAccountDb {
@@ -37,32 +39,38 @@ impl PostgresAccountDb {
 
 #[async_trait]
 impl AccountDb for PostgresAccountDb {
+    async fn find_subscription_end(
+        &self,
+        public_key: &PublicKey,
+    ) -> sqlx::Result<Option<DateTime<Utc>>> {
+        #[derive(FromRow)]
+        struct Row {
+            ends_at: DateTime<Utc>,
+        }
+        let public_key: String = public_key.to_sec1_bytes().encode_hex();
+        let row: Option<Row> =
+            query_as("SELECT ends_at FROM subscriptions WHERE public_key = $1 FOR UPDATE")
+                .bind(&public_key)
+                .fetch_optional(&self.pool.0)
+                .await?;
+        Ok(row.map(|r| r.ends_at))
+    }
+
     async fn credit_payment(
         &self,
         tx_hash: &str,
         public_key: PublicKey,
     ) -> Result<(), CreditPaymentError> {
-        #[derive(FromRow)]
-        struct Row {
-            ends_at: DateTime<Utc>,
-        }
         let mut tx = self.pool.0.begin().await?;
-        let public_key: String = public_key.to_sec1_bytes().encode_hex();
-        let subscription: Option<Row> =
-            query_as("SELECT ends_at FROM subscriptions WHERE public_key = $1 FOR UPDATE")
-                .bind(&public_key)
-                .fetch_optional(tx.deref_mut())
-                .await?;
-        if let Some(subscription) = &subscription {
-            if subscription.ends_at > Utc::now() + self.config.renewal_threshold {
-                info!(
-                    "Subscription can't be renewed because it ends at {}",
-                    subscription.ends_at
-                );
+        let subscription_ends_at = self.find_subscription_end(&public_key).await?;
+        if let Some(ends_at) = subscription_ends_at {
+            if ends_at > Utc::now() + self.config.renewal_threshold {
+                info!("Subscription can't be renewed because it ends at {ends_at}");
                 return Err(CreditPaymentError::CannotRenewYet);
             }
         }
 
+        let public_key: String = public_key.to_sec1_bytes().encode_hex();
         query("INSERT INTO payments (tx_hash, subscription_public_key, is_valid) VALUES ($1, $2, true)")
             .bind(tx_hash)
             .bind(&public_key)
@@ -71,8 +79,8 @@ impl AccountDb for PostgresAccountDb {
 
         // Try to extend it if it's not there yet
         let default_ends_at = Utc::now() + self.config.length;
-        let ends_at = subscription
-            .map(|s| s.ends_at + self.config.length)
+        let ends_at = subscription_ends_at
+            .map(|ends_at| ends_at + self.config.length)
             .unwrap_or(default_ends_at)
             .max(default_ends_at);
         query("INSERT INTO subscriptions (public_key, ends_at) VALUES ($1, $2) ON CONFLICT(public_key) DO UPDATE SET ends_at = $2")
@@ -87,7 +95,7 @@ impl AccountDb for PostgresAccountDb {
         &self,
         tx_hash: &str,
         public_key: PublicKey,
-    ) -> Result<(), sqlx::Error> {
+    ) -> sqlx::Result<()> {
         let public_key: String = public_key.to_sec1_bytes().encode_hex();
         query("INSERT INTO payments (tx_hash, subscription_public_key, is_valid) VALUES ($1, $2, false)")
             .bind(tx_hash)

--- a/src/run.rs
+++ b/src/run.rs
@@ -8,7 +8,7 @@ use axum_prometheus::{
     metrics_exporter_prometheus::PrometheusBuilder, EndpointLabel, PrometheusMetricLayerBuilder,
 };
 use nillion_chain_client::tx::DefaultPaymentTransactionRetriever;
-use std::{net::SocketAddr, time::Duration};
+use std::net::SocketAddr;
 use tokio::{join, net::TcpListener};
 use tracing::info;
 
@@ -28,7 +28,6 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     };
     let state = AppState {
         secret_key,
-        token_expiration: Duration::from_secs(config.tokens.expiration),
         services,
         databases,
     };

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,7 +2,7 @@ use crate::{db::account::AccountDb, time::TimeService};
 use axum::extract::State;
 use nillion_chain_client::tx::PaymentTransactionRetriever;
 use nillion_nucs::k256::SecretKey;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 pub(crate) type SharedState = State<Arc<AppState>>;
 
@@ -25,9 +25,6 @@ pub struct Databases {
 pub struct AppState {
     /// The server's secret key.
     pub secret_key: SecretKey,
-
-    /// The expiration time for tokens.
-    pub token_expiration: Duration,
 
     /// The services the application uses.
     pub services: Services,

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -112,6 +112,7 @@ impl Services {
         let nilauth = NilAuth {
             endpoint: format!("http://127.0.0.1:{}", config.server.bind_endpoint.port()),
             nilchain_client: Arc::new(tokio::sync::Mutex::new(nilchain_client)),
+            config: config.clone(),
         };
         let handle = RUNTIME.spawn(async move {
             match run(config).await {
@@ -141,6 +142,7 @@ struct StartedContainer<T: Image> {
 pub struct NilAuth {
     pub endpoint: String,
     pub nilchain_client: Arc<tokio::sync::Mutex<NillionChainClient>>,
+    pub config: Config,
 }
 
 #[fixture]


### PR DESCRIPTION
This adds the logic to:

* Only mint tokens if the user has a subscription.
* Set the `expires_at` for the token to the subscription's end time.