### PR TITLE
chore: UX improvements

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,28 @@
+use std::{
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn run_command<const N: usize>(command: &str, args: [&str; N]) -> String {
+    let output = Command::new(command)
+        .args(args)
+        .output()
+        .expect("failed to get run command");
+    String::from_utf8(output.stdout).expect("invalid command output")
+}
+
+fn git_hash() -> String {
+    run_command("git", ["rev-parse", "HEAD"])
+}
+
+fn main() {
+    let hash = git_hash();
+    let unix_now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT_HASH={hash}");
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={unix_now}");
+    println!("cargo:rustc-rerun-if-changed=.git/HEAD");
+}

--- a/src/routes/about.rs
+++ b/src/routes/about.rs
@@ -9,6 +9,8 @@ pub(crate) struct About {
     public_key: Box<[u8]>,
 
     build: BuildInfo,
+
+    started: DateTime<Utc>,
 }
 
 #[derive(Serialize)]
@@ -21,6 +23,7 @@ pub(crate) async fn handler(state: SharedState) -> Json<About> {
     let build_timestamp = env!("BUILD_TIMESTAMP").parse().unwrap_or(0);
     let build_timestamp = DateTime::from_timestamp(build_timestamp, 0).unwrap_or_default();
     About {
+        started: state.started_at,
         public_key: state.0.secret_key.public_key().to_sec1_bytes(),
         build: BuildInfo {
             commit: env!("BUILD_GIT_COMMIT_HASH").to_string(),

--- a/src/routes/about.rs
+++ b/src/routes/about.rs
@@ -1,16 +1,31 @@
 use crate::state::SharedState;
 use axum::Json;
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 #[derive(Serialize)]
 pub(crate) struct About {
     #[serde(serialize_with = "hex::serde::serialize")]
     public_key: Box<[u8]>,
+
+    build: BuildInfo,
+}
+
+#[derive(Serialize)]
+struct BuildInfo {
+    commit: String,
+    timestamp: DateTime<Utc>,
 }
 
 pub(crate) async fn handler(state: SharedState) -> Json<About> {
+    let build_timestamp = env!("BUILD_TIMESTAMP").parse().unwrap_or(0);
+    let build_timestamp = DateTime::from_timestamp(build_timestamp, 0).unwrap_or_default();
     About {
         public_key: state.0.secret_key.public_key().to_sec1_bytes(),
+        build: BuildInfo {
+            commit: env!("BUILD_GIT_COMMIT_HASH").to_string(),
+            timestamp: build_timestamp,
+        },
     }
     .into()
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,8 +1,12 @@
 use crate::state::AppState;
 use axum::{
+    extract::{rejection::JsonRejection, FromRequest, Request},
+    http::StatusCode,
+    response::IntoResponse,
     routing::{get, post},
     Router,
 };
+use serde::Serialize;
 use std::sync::Arc;
 
 pub(crate) mod about;
@@ -20,4 +24,47 @@ pub fn build_router(state: AppState) -> Router {
                 .route("/payments/validate", post(payments::validate::handler)),
         )
         .with_state(state)
+}
+
+/// An error when handling a request.
+#[derive(Debug, Serialize)]
+pub struct RequestHandlerError {
+    pub(crate) message: String,
+}
+
+/// A type that behaves like `axum::Json` but provides JSON structured errors when parsing fails.
+pub struct Json<T>(pub T);
+
+impl<S, T> FromRequest<S> for Json<T>
+where
+    axum::Json<T>: FromRequest<S, Rejection = JsonRejection>,
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, axum::Json<RequestHandlerError>);
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let (parts, body) = req.into_parts();
+        let req = Request::from_parts(parts, body);
+
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(value) => Ok(Self(value.0)),
+            Err(rejection) => {
+                // Construct a JSON error.
+                let payload = RequestHandlerError {
+                    message: rejection.body_text(),
+                };
+
+                Err((rejection.status(), axum::Json(payload)))
+            }
+        }
+    }
+}
+
+impl<T> IntoResponse for Json<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> axum::response::Response {
+        axum::Json(self.0).into_response()
+    }
 }

--- a/src/routes/nucs/create.rs
+++ b/src/routes/nucs/create.rs
@@ -1,8 +1,8 @@
-use crate::state::SharedState;
+use crate::routes::Json;
+use crate::{routes::RequestHandlerError, state::SharedState};
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
 };
 use chrono::{DateTime, Utc};
 use nillion_nucs::k256::{
@@ -131,7 +131,7 @@ pub(crate) enum HandlerError {
 
 impl IntoResponse for HandlerError {
     fn into_response(self) -> Response {
-        let output = match self {
+        let (code, message) = match self {
             Self::Internal => (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into()),
             Self::InvalidPublicKey => (StatusCode::BAD_REQUEST, "invalid public key".into()),
             Self::InvalidTargetPublicKey => {
@@ -153,7 +153,8 @@ impl IntoResponse for HandlerError {
                 "subscription expired".into(),
             ),
         };
-        output.into_response()
+        let response = RequestHandlerError { message };
+        (code, Json(response)).into_response()
     }
 }
 

--- a/src/routes/payments/validate.rs
+++ b/src/routes/payments/validate.rs
@@ -1,8 +1,8 @@
-use crate::{db::account::CreditPaymentError, state::SharedState};
+use crate::routes::Json;
+use crate::{db::account::CreditPaymentError, routes::RequestHandlerError, state::SharedState};
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
 };
 use nillion_chain_client::tx::RetrieveError;
 use nillion_nucs::k256::{
@@ -103,7 +103,7 @@ pub(crate) enum HandlerError {
 
 impl IntoResponse for HandlerError {
     fn into_response(self) -> Response {
-        let output = match self {
+        let (code, message) = match self {
             Self::CreditPayment(CreditPaymentError::Database) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into())
             }
@@ -140,7 +140,8 @@ impl IntoResponse for HandlerError {
                 }
             },
         };
-        output.into_response()
+        let response = RequestHandlerError { message };
+        (code, Json(response)).into_response()
     }
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -7,6 +7,7 @@ use axum::{routing::get, Router};
 use axum_prometheus::{
     metrics_exporter_prometheus::PrometheusBuilder, EndpointLabel, PrometheusMetricLayerBuilder,
 };
+use chrono::Utc;
 use nillion_chain_client::tx::DefaultPaymentTransactionRetriever;
 use std::net::SocketAddr;
 use tokio::{join, net::TcpListener};
@@ -30,6 +31,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         secret_key,
         services,
         databases,
+        started_at: Utc::now(),
     };
     // Create a custom prometheus layer that ignores unknown paths and returns `/unknown` instead so
     // crawlers/malicious actors can't create high cardinality metrics by hitting unknown routes.

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,6 @@
 use crate::{db::account::AccountDb, time::TimeService};
 use axum::extract::State;
+use chrono::{DateTime, Utc};
 use nillion_chain_client::tx::PaymentTransactionRetriever;
 use nillion_nucs::k256::SecretKey;
 use std::sync::Arc;
@@ -31,4 +32,7 @@ pub struct AppState {
 
     /// The database interfaces the application uses.
     pub databases: Databases,
+
+    /// The timestamp at which nilauth was started.
+    pub started_at: DateTime<Utc>,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -53,6 +53,7 @@ impl AppStateBuilder {
             databases: Databases {
                 accounts: Box::new(account_db),
             },
+            started_at: Utc::now(),
         })
     }
 


### PR DESCRIPTION
This:

* Includes a `build` key with git hash/build timestamp in `/about` just like with nildb so we can check which version we're running without having to ssh into the container.
* Turns the error response into a json object. For this I had to tweak the `Json` type being used, this is what axum folks suggest, to turn request decoding errors into JSON objets. Otherwise if you sent invalid JSON it would just and return a string with the error message.