### PR TITLE
feat: fetch token price from coingecko

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,17 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -122,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,7 +146,7 @@ checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -161,6 +178,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest 0.12.15",
  "rstest",
+ "rust_decimal",
  "serde",
  "serde_json",
  "serde_with",
@@ -324,6 +342,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +422,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b74d67a0fc0af8e9823b79fd1c43a0900e5a8f0e0f4cc9210796bf3a820126"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d37ed1b2c9b78421218a0b4f6d8349132d6ec2cfeba1cfb0118b0a8e268df9e"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +458,28 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -488,7 +563,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -691,7 +766,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -702,7 +777,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -755,7 +830,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -980,6 +1055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,7 +1127,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1164,6 +1245,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1558,7 +1642,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1774,7 +1858,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "portable-atomic",
 ]
 
@@ -1857,7 +1941,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2056,7 +2140,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.5",
  "structmeta",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2130,7 +2214,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2220,6 +2304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,7 +2341,27 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2317,7 +2430,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2334,6 +2447,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2482,6 +2601,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2727,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,8 +2798,24 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.99",
  "unicode-ident",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa7de2ba56ac291bd90c6b9bece784a52ae1411f9506544b3eae36dd2356d50"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2824,6 +2997,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,7 +3102,7 @@ checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2956,7 +3135,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3007,7 +3186,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3069,6 +3248,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -3180,7 +3365,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3203,7 +3388,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.99",
  "tempfile",
  "tokio",
  "url",
@@ -3346,7 +3531,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3357,7 +3542,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3380,6 +3565,17 @@ name = "subtle-ng"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3415,7 +3611,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3438,6 +3634,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3614,7 +3816,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3625,7 +3827,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3718,7 +3920,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3876,7 +4078,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4058,7 +4260,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -4093,7 +4295,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4474,6 +4676,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xattr"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4514,7 +4725,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -4545,7 +4756,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4556,7 +4767,7 @@ checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4576,7 +4787,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -4597,7 +4808,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4619,5 +4830,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ hex = { version = "0.4", features = ["serde"] }
 nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "1a3625ee1fe3fec045b9814202ce7e5f88faee56" }
 nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "1a3625ee1fe3fec045b9814202ce7e5f88faee56" }
 nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "1a3625ee1fe3fec045b9814202ce7e5f88faee56" }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+rust_decimal = "1.37"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.12"
@@ -28,7 +30,6 @@ tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "time"] }
 libc = "0.2"
 mockall = "0.13"
 rand = "0.8"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rstest = { version = "0.25", default-features = false }
 testcontainers-modules = { version = "0.11", features = ["blocking", "postgres"] }
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -14,5 +14,8 @@ payments:
     renewal_threshold_seconds: 60 
     length_seconds: 120
 
+  token_price:
+    api_key: abc 
+
 postgres:
   url: postgres://postgres:postgres@127.0.0.1:5432/postgres

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,6 +104,7 @@ pub struct SubscriptionConfig {
 }
 
 /// The token price configuration.
+#[serde_as]
 #[derive(Clone, Deserialize)]
 pub struct TokenPriceConfig {
     /// The base url to use.
@@ -116,6 +117,11 @@ pub struct TokenPriceConfig {
     /// The coin id to use when hitting the API.
     #[serde(default = "default_coin_id")]
     pub coin_id: String,
+
+    /// The timeout for all token price requests made.
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde(default = "default_token_price_timeout")]
+    pub request_timeout: Duration,
 }
 
 /// The postgres configuration.
@@ -131,4 +137,8 @@ fn default_token_price_base_url() -> String {
 
 fn default_coin_id() -> String {
     "nillion".into()
+}
+
+fn default_token_price_timeout() -> Duration {
+    Duration::from_secs(30)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,9 @@ pub struct PaymentsConfig {
 
     /// The subscription configuration.
     pub subscriptions: SubscriptionConfig,
+
+    /// The token price configuration.
+    pub token_price: TokenPriceConfig,
 }
 
 /// The subscription configuration.
@@ -100,9 +103,32 @@ pub struct SubscriptionConfig {
     pub length: Duration,
 }
 
+/// The token price configuration.
+#[derive(Clone, Deserialize)]
+pub struct TokenPriceConfig {
+    /// The base url to use.
+    #[serde(default = "default_token_price_base_url")]
+    pub base_url: String,
+
+    /// The API key for CoinGecko.
+    pub api_key: String,
+
+    /// The coin id to use when hitting the API.
+    #[serde(default = "default_coin_id")]
+    pub coin_id: String,
+}
+
 /// The postgres configuration.
 #[derive(Clone, Deserialize)]
 pub struct PostgresConfig {
     /// The connection string to use.
     pub url: String,
+}
+
+fn default_token_price_base_url() -> String {
+    "https://pro-api.coingecko.com/".into()
+}
+
+fn default_coin_id() -> String {
+    "nillion".into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod run;
 
 mod db;
 mod routes;
+mod services;
 mod state;
 mod time;
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::db::{account::PostgresAccountDb, PostgresPool};
+use crate::services::prices::CoinGeckoTokenPriceService;
 use crate::state::{AppState, Databases, Services};
 use crate::time::DefaultTimeService;
 use anyhow::Context;
@@ -20,6 +21,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             &config.payments.nilchain_url,
         )?),
         time: Box::new(DefaultTimeService),
+        prices: Box::new(CoinGeckoTokenPriceService::new(config.payments.token_price)),
     };
     let pool = PostgresPool::new(&config.postgres.url)
         .await

--- a/src/run.rs
+++ b/src/run.rs
@@ -21,7 +21,9 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             &config.payments.nilchain_url,
         )?),
         time: Box::new(DefaultTimeService),
-        prices: Box::new(CoinGeckoTokenPriceService::new(config.payments.token_price)),
+        prices: Box::new(CoinGeckoTokenPriceService::new(
+            config.payments.token_price,
+        )?),
     };
     let pool = PostgresPool::new(&config.postgres.url)
         .await

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod prices;

--- a/src/services/prices.rs
+++ b/src/services/prices.rs
@@ -1,0 +1,106 @@
+use crate::config::TokenPriceConfig;
+use anyhow::{anyhow, bail};
+use async_trait::async_trait;
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use std::{collections::HashMap, time::Duration};
+use tokio::{sync::Mutex, time::Instant};
+use tracing::info;
+
+const PRICE_CACHE_DURATION: Duration = Duration::from_secs(60);
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub(crate) trait TokenPriceService: Send + Sync + 'static {
+    async fn nil_token_price(&self) -> anyhow::Result<Decimal>;
+}
+
+/// An implementation of the token price service that uses CoinGecko to retrieve the price.
+pub(crate) struct CoinGeckoTokenPriceService {
+    client: reqwest::Client,
+    api_key: String,
+    coin_id: String,
+    simple_price_url: String,
+    last_price: Mutex<CachedPrice>,
+}
+
+impl CoinGeckoTokenPriceService {
+    pub(crate) fn new(config: TokenPriceConfig) -> Self {
+        let TokenPriceConfig {
+            base_url,
+            api_key,
+            coin_id,
+        } = config;
+        Self {
+            client: reqwest::Client::new(),
+            api_key,
+            coin_id,
+            simple_price_url: format!("{base_url}/api/v3/simple/price"),
+            last_price: Mutex::new(CachedPrice {
+                timestamp: Instant::now() - PRICE_CACHE_DURATION - Duration::from_secs(1),
+                price: Decimal::from(0),
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl TokenPriceService for CoinGeckoTokenPriceService {
+    async fn nil_token_price(&self) -> anyhow::Result<Decimal> {
+        let mut last_price = self.last_price.lock().await;
+        if last_price.timestamp.elapsed() < PRICE_CACHE_DURATION {
+            return Ok(last_price.price);
+        }
+
+        let params = [("ids", self.coin_id.as_str()), ("vs_currencies", "usd")];
+        info!("Fetching token price from CoinGecko");
+
+        let response = self
+            .client
+            .get(&self.simple_price_url)
+            .query(&params)
+            .header("X-CG-PRO-API-KEY", &self.api_key)
+            .send()
+            .await;
+
+        let response = match response {
+            Ok(response) => response,
+            Err(e) => {
+                bail!("Failed to fetch token price from CoinGecko: {e}");
+            }
+        };
+
+        let response: HashMap<String, TokenPrice> = response
+            .json()
+            .await
+            .map_err(|e| anyhow!("invalid JSON response from CoinGecko: {e}"))?;
+
+        let price = response
+            .get(&self.coin_id)
+            .map(|response| response.usd)
+            .ok_or_else(|| anyhow!("CoinGecko response dot not contain the requeste coin"))?;
+        // Just in case...
+        if price <= Decimal::from(0) {
+            bail!("token price is <= 0: {price}")
+        }
+
+        info!("Token price from CoinGecko: {price}");
+
+        *last_price = CachedPrice {
+            timestamp: Instant::now(),
+            price,
+        };
+        Ok(price)
+    }
+}
+
+struct CachedPrice {
+    timestamp: Instant,
+    price: Decimal,
+}
+
+// The type returned from coingecko containing the usd price for a token.
+#[derive(Debug, Deserialize)]
+struct TokenPrice {
+    usd: Decimal,
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{db::account::AccountDb, time::TimeService};
+use crate::{db::account::AccountDb, services::prices::TokenPriceService, time::TimeService};
 use axum::extract::State;
 use chrono::{DateTime, Utc};
 use nillion_chain_client::tx::PaymentTransactionRetriever;
@@ -14,6 +14,9 @@ pub struct Services {
 
     /// A service that provides the current time.
     pub time: Box<dyn TimeService>,
+
+    /// A service that gets the current token price.
+    pub prices: Box<dyn TokenPriceService>,
 }
 
 /// Database interfaces used by the application.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use crate::db::account::MockAccountDb;
+use crate::services::prices::MockTokenPriceService;
 use crate::state::{AppState, Databases, Services};
 use crate::time::MockTimeService;
 use async_trait::async_trait;
@@ -21,6 +22,7 @@ pub(crate) struct AppStateBuilder {
     pub(crate) secret_key: SecretKey,
     pub(crate) tx_retriever: MockPaymentRetriever,
     pub(crate) time_service: MockTimeService,
+    pub(crate) token_price_service: MockTokenPriceService,
     pub(crate) account_db: MockAccountDb,
 }
 
@@ -30,6 +32,7 @@ impl Default for AppStateBuilder {
             secret_key: SecretKey::random(&mut rand::thread_rng()),
             tx_retriever: Default::default(),
             time_service: Default::default(),
+            token_price_service: Default::default(),
             account_db: Default::default(),
         }
     }
@@ -41,6 +44,7 @@ impl AppStateBuilder {
             secret_key,
             tx_retriever,
             time_service,
+            token_price_service,
             account_db,
         } = self;
 
@@ -49,6 +53,7 @@ impl AppStateBuilder {
             services: Services {
                 tx: Box::new(tx_retriever),
                 time: Box::new(time_service),
+                prices: Box::new(token_price_service),
             },
             databases: Databases {
                 accounts: Box::new(account_db),


### PR DESCRIPTION
This adds the logic to fetch the coin price from coingecko. Nothing is using this for now but I'll add that logic in another PR once the client supports it.

The code was mostly pulled from nilvm but tweaked slightly. I also added a mock server in integration tests that replies to the endpoint with a $1 price.