### PR TITLE
chore: rename uses of `authority_service`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,38 +159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nilauth"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "axum-prometheus",
- "chrono",
- "clap",
- "config",
- "hex",
- "libc",
- "mockall",
- "nilauth-client",
- "nillion-chain-client",
- "nillion-nucs",
- "rand 0.8.5",
- "reqwest 0.12.15",
- "rstest",
- "rust_decimal",
- "serde",
- "serde_json",
- "serde_with",
- "sqlx",
- "testcontainers-modules",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,9 +1913,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "nilauth"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "axum-prometheus",
+ "chrono",
+ "clap",
+ "config",
+ "hex",
+ "libc",
+ "mockall",
+ "nilauth-client",
+ "nillion-chain-client",
+ "nillion-nucs",
+ "rand 0.8.5",
+ "reqwest 0.12.15",
+ "rstest",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sqlx",
+ "testcontainers-modules",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "nilauth-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=957a4b92a406585424bd1e7c1e9e51197e457b94#957a4b92a406585424bd1e7c1e9e51197e457b94"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc#3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "nillion-chain-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=957a4b92a406585424bd1e7c1e9e51197e457b94#957a4b92a406585424bd1e7c1e9e51197e457b94"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc#3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "nillion-chain-transactions"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=957a4b92a406585424bd1e7c1e9e51197e457b94#957a4b92a406585424bd1e7c1e9e51197e457b94"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc#3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc"
 dependencies = [
  "prost",
 ]
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "nillion-nucs"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=957a4b92a406585424bd1e7c1e9e51197e457b94#957a4b92a406585424bd1e7c1e9e51197e457b94"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc#3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "env"] }
 config = { version = "0.15", default-features = false, features = ["yaml"] }
 hex = { version = "0.4", features = ["serde"] }
-nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "957a4b92a406585424bd1e7c1e9e51197e457b94" }
-nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "957a4b92a406585424bd1e7c1e9e51197e457b94" }
-nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "957a4b92a406585424bd1e7c1e9e51197e457b94" }
+nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc" }
+nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc" }
+nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "3b307cfa661baead3b64e6f7cb0f9a3d93cc38dc" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rust_decimal = "1.37"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use authority_service::args::Cli;
-use authority_service::config::Config;
-use authority_service::run::run;
 use clap::Parser;
+use nilauth::args::Cli;
+use nilauth::config::Config;
+use nilauth::run::run;
 use std::process::exit;
 
 #[tokio::main]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,7 +11,7 @@ mod setup;
 #[rstest]
 #[tokio::test]
 async fn pay_and_mint(nilauth: NilAuth) {
-    let client = DefaultNilauthClient::new(nilauth.endpoint);
+    let client = DefaultNilauthClient::new(nilauth.endpoint).expect("failed to build client");
     let key = SecretKey::random(&mut rand::thread_rng());
     client
         .pay_subscription(
@@ -51,7 +51,7 @@ async fn pay_and_mint(nilauth: NilAuth) {
 #[rstest]
 #[tokio::test]
 async fn mint_without_paying(nilauth: NilAuth) {
-    let client = DefaultNilauthClient::new(nilauth.endpoint);
+    let client = DefaultNilauthClient::new(nilauth.endpoint).expect("failed to build client");
     let key = SecretKey::random(&mut rand::thread_rng());
     client
         .request_token(&key)
@@ -62,7 +62,7 @@ async fn mint_without_paying(nilauth: NilAuth) {
 #[rstest]
 #[tokio::test]
 async fn pay_too_soon(nilauth: NilAuth) {
-    let client = DefaultNilauthClient::new(nilauth.endpoint);
+    let client = DefaultNilauthClient::new(nilauth.endpoint).expect("failed to build client");
     let key = SecretKey::random(&mut rand::thread_rng());
     client
         .pay_subscription(

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -1,4 +1,4 @@
-use authority_service::{config::Config, run::run};
+use ::nilauth::{config::Config, run::run};
 use axum::http::StatusCode;
 use axum::routing::get;
 use axum::Router;


### PR DESCRIPTION
The build is currently broken after the `authority_service -> nilauth` rename. This also pulls the nilvm main which changed the return type for the nilauth client's `new` function.