### PR TITLE
feat: cleanup expired revocations periodically

### DIFF
--- a/migrations/20250328142149_add_revocations_expiration_time_index.sql
+++ b/migrations/20250328142149_add_revocations_expiration_time_index.sql
@@ -1,0 +1,3 @@
+-- Add an index on the revocations table to lookup by expiration time
+
+CREATE INDEX revocations_expires_at ON revocations (expires_at);

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -1,0 +1,64 @@
+use crate::{db::revocations::RevocationDb, time::TimeService};
+use std::{sync::Arc, time::Duration};
+use tokio::time::sleep;
+use tracing::{error, info};
+
+const CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+const CLEANUP_GRACE_PERIOD: Duration = Duration::from_secs(60);
+
+pub(crate) struct RevokedTokenCleaner {
+    db: Arc<dyn RevocationDb>,
+    time: Box<dyn TimeService>,
+}
+
+impl RevokedTokenCleaner {
+    pub(crate) fn spawn(db: Arc<dyn RevocationDb>, time: Box<dyn TimeService>) {
+        let this = Self { db, time };
+        tokio::spawn(async move { this.run().await });
+    }
+
+    async fn run(self) {
+        loop {
+            if let Err(e) = self.try_delete().await {
+                error!("Failed to delete expired revoked tokens: {e}");
+            }
+            info!("Sleeping for {CLEANUP_INTERVAL:?}");
+            sleep(CLEANUP_INTERVAL).await;
+        }
+    }
+
+    async fn try_delete(&self) -> anyhow::Result<()> {
+        // Delete tokens expired a few seconds ago, just in case our clock drifted a little. We
+        // don't want to risk allowing a revoked token to be considered valid.
+        let cleanup_threshold = self.time.current_time() - CLEANUP_GRACE_PERIOD;
+        info!("Deleting revoked tokens expired before {cleanup_threshold}");
+        let expired_count = self.db.delete_expired(cleanup_threshold).await?;
+        info!("Deleted {expired_count} expired revoked tokens");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{db::revocations::MockRevocationDb, time::MockTimeService};
+    use chrono::Utc;
+    use mockall::predicate::eq;
+
+    #[tokio::test]
+    async fn cleanup() {
+        let mut db = MockRevocationDb::default();
+        let mut time = MockTimeService::default();
+        let now = Utc::now();
+        time.expect_current_time().return_once(move || now);
+        db.expect_delete_expired()
+            .with(eq(now - CLEANUP_GRACE_PERIOD))
+            .return_once(|_| Ok(1));
+
+        let cleaner = RevokedTokenCleaner {
+            db: Arc::new(db),
+            time: Box::new(time),
+        };
+        cleaner.try_delete().await.expect("failed to delete");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod run;
 
 mod auth;
+mod cleanup;
 mod db;
 mod routes;
 mod services;

--- a/src/state.rs
+++ b/src/state.rs
@@ -30,7 +30,7 @@ pub struct Databases {
     pub accounts: Box<dyn AccountDb>,
 
     /// The revocations database.
-    pub revocations: Box<dyn RevocationDb>,
+    pub revocations: Arc<dyn RevocationDb>,
 }
 
 /// The state to be shared across all routes.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -79,7 +79,7 @@ impl AppStateBuilder {
             },
             databases: Databases {
                 accounts: Box::new(account_db),
-                revocations: Box::new(revocation_db),
+                revocations: Arc::new(revocation_db),
             },
         })
     }


### PR DESCRIPTION
This adds the logic to cleanup expired revocations. This currently runs every 60 seconds and cleans up revoked tokens that were expired 60 seconds ago, just in case clock drifts play against us.

I will do a follow up PR adding metrics all over the service, including here.