### PR TITLE
feat: add health endpoint

### DIFF
--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,0 +1,6 @@
+use axum::response::{IntoResponse, Response};
+use reqwest::StatusCode;
+
+pub(crate) async fn handler() -> Response {
+    (StatusCode::OK, "OK").into_response()
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 use std::sync::Arc;
 
 pub(crate) mod about;
+pub(crate) mod health;
 pub(crate) mod nucs;
 pub(crate) mod payments;
 pub(crate) mod revocations;
@@ -30,6 +31,7 @@ pub fn build_router(state: AppState) -> Router {
     let validator_state = TokenValidatorState::new(validator, nilauth_did);
     Router::new()
         .route("/about", get(about::handler))
+        .route("/health", get(health::handler))
         .nest(
             "/api/v1/",
             Router::new()


### PR DESCRIPTION
The ecs-service infra hits `/health` as a health check and since we don't have this implemented it's constantly being restarted.