### PR TITLE
chore: include error codes in responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +1932,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "convert_case",
  "hex",
  "itertools",
  "libc",
@@ -1939,6 +1949,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sqlx",
+ "strum",
  "testcontainers-modules",
  "thiserror 2.0.12",
  "tokio",
@@ -3548,6 +3559,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,9 +3933,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4145,6 +4178,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "nilauth-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=e30037128e8142e2d7d8f7cbd6e0914bf9fb250b#e30037128e8142e2d7d8f7cbd6e0914bf9fb250b"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=b37855e123571df0a767a2cb9f9c8cfee8af5823#b37855e123571df0a767a2cb9f9c8cfee8af5823"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1972,12 +1972,14 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "nillion-chain-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=e30037128e8142e2d7d8f7cbd6e0914bf9fb250b#e30037128e8142e2d7d8f7cbd6e0914bf9fb250b"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=b37855e123571df0a767a2cb9f9c8cfee8af5823#b37855e123571df0a767a2cb9f9c8cfee8af5823"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1998,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "nillion-chain-transactions"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=e30037128e8142e2d7d8f7cbd6e0914bf9fb250b#e30037128e8142e2d7d8f7cbd6e0914bf9fb250b"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=b37855e123571df0a767a2cb9f9c8cfee8af5823#b37855e123571df0a767a2cb9f9c8cfee8af5823"
 dependencies = [
  "prost",
 ]
@@ -2006,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "nillion-nucs"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=e30037128e8142e2d7d8f7cbd6e0914bf9fb250b#e30037128e8142e2d7d8f7cbd6e0914bf9fb250b"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=b37855e123571df0a767a2cb9f9c8cfee8af5823#b37855e123571df0a767a2cb9f9c8cfee8af5823"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ axum-prometheus = "0.8"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "env"] }
 config = { version = "0.15", default-features = false, features = ["yaml"] }
+convert_case = "0.8"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.14"
 metrics = "0.24"
@@ -22,11 +23,12 @@ rust_decimal = "1.37"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.12"
+strum = { version = "0.27", features = ["derive"] }
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio", "chrono"] }
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "time"] }
 
 [dev-dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ convert_case = "0.8"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.14"
 metrics = "0.24"
-nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "e30037128e8142e2d7d8f7cbd6e0914bf9fb250b" }
-nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "e30037128e8142e2d7d8f7cbd6e0914bf9fb250b" }
-nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "e30037128e8142e2d7d8f7cbd6e0914bf9fb250b" }
+nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "b37855e123571df0a767a2cb9f9c8cfee8af5823" }
+nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "b37855e123571df0a767a2cb9f9c8cfee8af5823" }
+nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "b37855e123571df0a767a2cb9f9c8cfee8af5823" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rust_decimal = "1.37"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -28,9 +28,7 @@ where
                 error!("Token validator state not configured");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(RequestHandlerError {
-                        message: "internal error".into(),
-                    }),
+                    Json(RequestHandlerError::new("internal error", "INTERNAL")),
                 )
             })?;
         let payload = match parts.headers.get(AUTHORIZATION_HEADER) {
@@ -63,9 +61,7 @@ where
 fn make_unauthorized(message: impl Into<String>) -> (StatusCode, Json<RequestHandlerError>) {
     (
         StatusCode::UNAUTHORIZED,
-        Json(RequestHandlerError {
-            message: message.into(),
-        }),
+        Json(RequestHandlerError::new(message, "UNAUTHORIZED")),
     )
 }
 

--- a/src/routes/payments/cost.rs
+++ b/src/routes/payments/cost.rs
@@ -5,6 +5,7 @@ use axum::response::{IntoResponse, Response};
 use metrics::counter;
 use rust_decimal::Decimal;
 use serde::Serialize;
+use strum::EnumDiscriminants;
 use tracing::error;
 
 pub(crate) static UNIL_IN_NIL: u64 = 1_000_000;
@@ -35,17 +36,18 @@ pub(crate) async fn handler(state: SharedState) -> Result<Json<GetCostResponse>,
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, EnumDiscriminants)]
 pub(crate) enum HandlerError {
     Internal,
 }
 
 impl IntoResponse for HandlerError {
     fn into_response(self) -> Response {
+        let discriminant = HandlerErrorDiscriminants::from(&self);
         let (code, message) = match self {
-            Self::Internal => (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into()),
+            Self::Internal => (StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
         };
-        let response = RequestHandlerError { message };
+        let response = RequestHandlerError::new(message, format!("{discriminant:?}"));
         (code, Json(response)).into_response()
     }
 }

--- a/src/routes/payments/validate.rs
+++ b/src/routes/payments/validate.rs
@@ -13,6 +13,7 @@ use nillion_nucs::k256::{
 };
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use strum::EnumDiscriminants;
 use tracing::{error, info, warn};
 
 #[derive(Deserialize)]
@@ -59,12 +60,7 @@ pub(crate) async fn handler(
 
     // Make sure the client has proven they made the transaction
     let tx_hash = request.tx_hash;
-    let tx = state
-        .services
-        .tx
-        .get(&tx_hash)
-        .await
-        .map_err(HandlerError::RetrieveTransaction)?;
+    let tx = state.services.tx.get(&tx_hash).await?;
     let payload_hash = Sha256::digest(&request.payload);
     if tx.resource != payload_hash.as_slice() {
         store_invalid_payment(&state, &tx_hash, public_key).await;
@@ -117,7 +113,7 @@ async fn store_invalid_payment(state: &SharedState, tx_hash: &str, public_key: P
     };
 }
 
-#[derive(Debug)]
+#[derive(Debug, EnumDiscriminants)]
 pub(crate) enum HandlerError {
     CreditPayment(CreditPaymentError),
     HashMismatch,
@@ -126,11 +122,24 @@ pub(crate) enum HandlerError {
     Internal,
     MalformedPayload(String),
     UnknownPublicKey,
-    RetrieveTransaction(RetrieveError),
+    TransactionNotCommitted,
+    MalformedTransaction,
+    TransactionLookup,
+}
+
+impl From<RetrieveError> for HandlerError {
+    fn from(e: RetrieveError) -> Self {
+        match e {
+            RetrieveError::NotCommitted => Self::TransactionNotCommitted,
+            RetrieveError::Malformed(_) => Self::MalformedTransaction,
+            RetrieveError::TransactionFetch(_) => Self::TransactionLookup,
+        }
+    }
 }
 
 impl IntoResponse for HandlerError {
     fn into_response(self) -> Response {
+        let discriminant = HandlerErrorDiscriminants::from(&self);
         let (code, message) = match self {
             Self::CreditPayment(CreditPaymentError::Database) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into())
@@ -160,20 +169,17 @@ impl IntoResponse for HandlerError {
                 StatusCode::BAD_REQUEST,
                 "payload public key is different from ours".into(),
             ),
-            Self::RetrieveTransaction(e) => match e {
-                RetrieveError::NotCommitted => (
-                    StatusCode::TOO_EARLY,
-                    "transaction is not committed yet".into(),
-                ),
-                RetrieveError::Malformed(_) => {
-                    (StatusCode::BAD_REQUEST, "transaction is malformed".into())
-                }
-                RetrieveError::TransactionFetch(_) => {
-                    (StatusCode::NOT_FOUND, "transaction not found".into())
-                }
-            },
+            Self::TransactionNotCommitted => (
+                StatusCode::PRECONDITION_FAILED,
+                "transaction is not yet committed".into(),
+            ),
+            Self::MalformedTransaction => (
+                StatusCode::BAD_REQUEST,
+                "transaction payload is malformed".into(),
+            ),
+            Self::TransactionLookup => (StatusCode::NOT_FOUND, "transaction not found".into()),
         };
-        let response = RequestHandlerError { message };
+        let response = RequestHandlerError::new(message, format!("{discriminant:?}"));
         (code, Json(response)).into_response()
     }
 }
@@ -345,6 +351,6 @@ mod tests {
             })
             .await
             .expect_err("request succeeded");
-        assert!(matches!(err, HandlerError::RetrieveTransaction(_)));
+        assert!(matches!(err, HandlerError::TransactionNotCommitted));
     }
 }

--- a/src/routes/payments/validate.rs
+++ b/src/routes/payments/validate.rs
@@ -162,7 +162,7 @@ impl IntoResponse for HandlerError {
             ),
             Self::RetrieveTransaction(e) => match e {
                 RetrieveError::NotCommitted => (
-                    StatusCode::PRECONDITION_FAILED,
+                    StatusCode::TOO_EARLY,
                     "transaction is not committed yet".into(),
                 ),
                 RetrieveError::Malformed(_) => {


### PR DESCRIPTION
This returns error codes in all errors. This is done automatically by using `strum::EnumDiscriminants` over the enum that represents the errors in each handler. This will allow the client to retry for a payment transaction if the error code is `TRANSACTION_NOT_COMMITED`