### PR TITLE
revert: disable arm64 docker builds

### DIFF
--- a/.github/workflows/cd-image.yml
+++ b/.github/workflows/cd-image.yml
@@ -58,8 +58,7 @@ jobs:
             TAGS="$TAGS -t ${ECR_REGISTRY_URL}:latest"
           fi
 
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
+           docker build \
             --push \
             -f Dockerfile \
             $TAGS \


### PR DESCRIPTION
The ci job for the arm64 image was at 50 minutes and still going which is not practical. Its likely that we'll have to use arm64 and amd64 machines if we want to support different architectures but its not a priority at the moment.