### PR TITLE
feat: add subscription status endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "nilauth-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=b0cd7c8f5cb2cba101e0d45abe20e1f48d263621#b0cd7c8f5cb2cba101e0d45abe20e1f48d263621"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=7d8aa9c96f681047107b11f45d2bffd1b95bcd19#7d8aa9c96f681047107b11f45d2bffd1b95bcd19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "nillion-chain-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=b0cd7c8f5cb2cba101e0d45abe20e1f48d263621#b0cd7c8f5cb2cba101e0d45abe20e1f48d263621"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=7d8aa9c96f681047107b11f45d2bffd1b95bcd19#7d8aa9c96f681047107b11f45d2bffd1b95bcd19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2000,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "nillion-chain-transactions"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=b0cd7c8f5cb2cba101e0d45abe20e1f48d263621#b0cd7c8f5cb2cba101e0d45abe20e1f48d263621"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=7d8aa9c96f681047107b11f45d2bffd1b95bcd19#7d8aa9c96f681047107b11f45d2bffd1b95bcd19"
 dependencies = [
  "prost",
 ]
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "nillion-nucs"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=b0cd7c8f5cb2cba101e0d45abe20e1f48d263621#b0cd7c8f5cb2cba101e0d45abe20e1f48d263621"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=7d8aa9c96f681047107b11f45d2bffd1b95bcd19#7d8aa9c96f681047107b11f45d2bffd1b95bcd19"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "nilauth-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=b37855e123571df0a767a2cb9f9c8cfee8af5823#b37855e123571df0a767a2cb9f9c8cfee8af5823"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=b0cd7c8f5cb2cba101e0d45abe20e1f48d263621#b0cd7c8f5cb2cba101e0d45abe20e1f48d263621"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "nillion-chain-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=b37855e123571df0a767a2cb9f9c8cfee8af5823#b37855e123571df0a767a2cb9f9c8cfee8af5823"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=b0cd7c8f5cb2cba101e0d45abe20e1f48d263621#b0cd7c8f5cb2cba101e0d45abe20e1f48d263621"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2000,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "nillion-chain-transactions"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=b37855e123571df0a767a2cb9f9c8cfee8af5823#b37855e123571df0a767a2cb9f9c8cfee8af5823"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=b0cd7c8f5cb2cba101e0d45abe20e1f48d263621#b0cd7c8f5cb2cba101e0d45abe20e1f48d263621"
 dependencies = [
  "prost",
 ]
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "nillion-nucs"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=b37855e123571df0a767a2cb9f9c8cfee8af5823#b37855e123571df0a767a2cb9f9c8cfee8af5823"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=b0cd7c8f5cb2cba101e0d45abe20e1f48d263621#b0cd7c8f5cb2cba101e0d45abe20e1f48d263621"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ convert_case = "0.8"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.14"
 metrics = "0.24"
-nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "b0cd7c8f5cb2cba101e0d45abe20e1f48d263621" }
-nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "b0cd7c8f5cb2cba101e0d45abe20e1f48d263621" }
-nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "b0cd7c8f5cb2cba101e0d45abe20e1f48d263621" }
+nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "7d8aa9c96f681047107b11f45d2bffd1b95bcd19" }
+nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "7d8aa9c96f681047107b11f45d2bffd1b95bcd19" }
+nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "7d8aa9c96f681047107b11f45d2bffd1b95bcd19" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rust_decimal = "1.37"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ convert_case = "0.8"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.14"
 metrics = "0.24"
-nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "b37855e123571df0a767a2cb9f9c8cfee8af5823" }
-nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "b37855e123571df0a767a2cb9f9c8cfee8af5823" }
-nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "b37855e123571df0a767a2cb9f9c8cfee8af5823" }
+nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "b0cd7c8f5cb2cba101e0d45abe20e1f48d263621" }
+nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "b0cd7c8f5cb2cba101e0d45abe20e1f48d263621" }
+nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "b0cd7c8f5cb2cba101e0d45abe20e1f48d263621" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rust_decimal = "1.37"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub struct ServerConfig {
 #[serde(rename_all = "snake_case")]
 pub enum PrivateKeyConfig {
     /// The raw private key in hex.
-    Hex(#[serde(deserialize_with = "hex::serde::deserialize")] [u8; 32]),
+    Hex(#[serde(with = "hex::serde")] [u8; 32]),
 
     /// The path to the private key.
     Path(PathBuf),

--- a/src/db/revocations.rs
+++ b/src/db/revocations.rs
@@ -135,7 +135,7 @@ impl RevocationDb for PostgresRevocationDb {
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct RevokedToken {
     /// The token hash.
-    #[serde(serialize_with = "hex::serde::serialize")]
+    #[serde(with = "hex::serde")]
     pub(crate) token_hash: Vec<u8>,
 
     /// The timestamp at which the token was revoked.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod cleanup;
 mod db;
 mod routes;
 mod services;
+mod signed;
 mod state;
 mod time;
 

--- a/src/routes/about.rs
+++ b/src/routes/about.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 #[derive(Serialize)]
 pub(crate) struct About {
-    #[serde(serialize_with = "hex::serde::serialize")]
+    #[serde(with = "hex::serde")]
     public_key: Box<[u8]>,
 
     build: BuildInfo,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod health;
 pub(crate) mod nucs;
 pub(crate) mod payments;
 pub(crate) mod revocations;
+pub(crate) mod subscriptions;
 
 pub fn build_router(state: AppState) -> Router {
     let state = Arc::new(state);
@@ -40,7 +41,11 @@ pub fn build_router(state: AppState) -> Router {
                 .route("/payments/validate", post(payments::validate::handler))
                 .route("/payments/cost", get(payments::cost::handler))
                 .route("/revocations/revoke", post(revocations::revoke::handler))
-                .route("/revocations/lookup", post(revocations::lookup::handler)),
+                .route("/revocations/lookup", post(revocations::lookup::handler))
+                .route(
+                    "/subscriptions/status",
+                    post(subscriptions::status::handler),
+                ),
         )
         .with_state(state)
         .layer(Extension(validator_state))

--- a/src/routes/payments/validate.rs
+++ b/src/routes/payments/validate.rs
@@ -20,10 +20,10 @@ use tracing::{error, info, warn};
 pub(crate) struct ValidatePaymentRequest {
     tx_hash: String,
 
-    #[serde(deserialize_with = "hex::serde::deserialize")]
+    #[serde(with = "hex::serde")]
     payload: Vec<u8>,
 
-    #[serde(deserialize_with = "hex::serde::deserialize")]
+    #[serde(with = "hex::serde")]
     public_key: [u8; 33],
 }
 
@@ -31,16 +31,10 @@ pub(crate) struct ValidatePaymentRequest {
 #[serde(deny_unknown_fields)]
 struct Payload {
     #[allow(dead_code)]
-    #[serde(
-        serialize_with = "hex::serde::serialize",
-        deserialize_with = "hex::serde::deserialize"
-    )]
+    #[serde(with = "hex::serde")]
     nonce: [u8; 16],
 
-    #[serde(
-        serialize_with = "hex::serde::serialize",
-        deserialize_with = "hex::serde::deserialize"
-    )]
+    #[serde(with = "hex::serde")]
     service_public_key: Vec<u8>,
 }
 

--- a/src/routes/subscriptions/mod.rs
+++ b/src/routes/subscriptions/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod status;

--- a/src/routes/subscriptions/status.rs
+++ b/src/routes/subscriptions/status.rs
@@ -1,0 +1,190 @@
+use crate::routes::Json;
+use crate::signed::{SignedRequest, VerificationError};
+use crate::{routes::RequestHandlerError, state::SharedState};
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use strum::EnumDiscriminants;
+use tracing::error;
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Payload {
+    #[allow(dead_code)]
+    #[serde(with = "hex::serde")]
+    nonce: [u8; 16],
+
+    #[serde(with = "chrono::serde::ts_seconds")]
+    expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SubscriptionStatusResponse {
+    subscribed: bool,
+    subscription: Option<Subscription>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub(crate) struct Subscription {
+    #[serde(with = "chrono::serde::ts_seconds")]
+    expires_at: DateTime<Utc>,
+}
+
+pub(crate) async fn handler(
+    state: SharedState,
+    Json(request): Json<SignedRequest>,
+) -> Result<Json<SubscriptionStatusResponse>, HandlerError> {
+    let decoded_payload: Payload = serde_json::from_slice(&request.payload)
+        .map_err(|e| HandlerError::MalformedPayload(e.to_string()))?;
+    if decoded_payload.expires_at <= state.services.time.current_time() {
+        return Err(HandlerError::PayloadExpired);
+    }
+    let public_key = request.verify()?;
+    let expires_at = state
+        .databases
+        .accounts
+        .find_subscription_end(&public_key)
+        .await
+        .map_err(|e| {
+            error!("Subscription lookup failed: {e}");
+            HandlerError::Internal
+        })?;
+    let subscription = expires_at.map(|expires_at| Subscription { expires_at });
+    let subscribed = subscription.is_some();
+    Ok(Json(SubscriptionStatusResponse {
+        subscribed,
+        subscription,
+    }))
+}
+
+#[derive(Debug, EnumDiscriminants)]
+pub(crate) enum HandlerError {
+    Internal,
+    InvalidPublicKey,
+    InvalidSignature,
+    MalformedPayload(String),
+    PayloadExpired,
+    SignatureVerification,
+}
+
+impl From<VerificationError> for HandlerError {
+    fn from(e: VerificationError) -> Self {
+        match e {
+            VerificationError::InvalidPublicKey => Self::InvalidPublicKey,
+            VerificationError::InvalidSignature => Self::InvalidSignature,
+            VerificationError::SignatureVerification => Self::SignatureVerification,
+        }
+    }
+}
+
+impl IntoResponse for HandlerError {
+    fn into_response(self) -> Response {
+        let discriminant = HandlerErrorDiscriminants::from(&self);
+        let (code, message) = match self {
+            Self::Internal => (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into()),
+            Self::InvalidPublicKey => (StatusCode::BAD_REQUEST, "invalid public key".into()),
+            Self::InvalidSignature => (StatusCode::BAD_REQUEST, "invalid signature".into()),
+            Self::MalformedPayload(reason) => (
+                StatusCode::BAD_REQUEST,
+                format!("malformed payload: {reason}"),
+            ),
+            Self::PayloadExpired => (StatusCode::BAD_REQUEST, "payload expired".into()),
+            Self::SignatureVerification => (
+                StatusCode::BAD_REQUEST,
+                "signature verification failed".into(),
+            ),
+        };
+        let response = RequestHandlerError::new(message, format!("{discriminant:?}"));
+        (code, Json(response)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::extract::State;
+    use mockall::predicate::eq;
+    use nillion_nucs::k256::SecretKey;
+
+    use super::*;
+    use crate::tests::AppStateBuilder;
+    use std::time::Duration;
+
+    struct Handler {
+        builder: AppStateBuilder,
+    }
+
+    impl Default for Handler {
+        fn default() -> Self {
+            let builder = AppStateBuilder::default();
+            Self { builder }
+        }
+    }
+
+    impl Handler {
+        async fn invoke(
+            self,
+            request: SignedRequest,
+        ) -> Result<SubscriptionStatusResponse, HandlerError> {
+            let state = self.builder.build();
+            let request = Json(request);
+            handler(State(state), request).await.map(|r| r.0)
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_request() {
+        let mut handler = Handler::default();
+        let key = SecretKey::random(&mut rand::thread_rng());
+        let now = Utc::now();
+        let timestamp = Utc::now();
+        handler
+            .builder
+            .time_service
+            .expect_current_time()
+            .returning(move || now);
+
+        handler
+            .builder
+            .account_db
+            .expect_find_subscription_end()
+            .with(eq(key.public_key()))
+            .return_once(move |_| Ok(Some(timestamp)));
+
+        let payload = Payload {
+            nonce: rand::random(),
+            expires_at: now + Duration::from_secs(60),
+        };
+        let request = SignedRequest::new(&key, &payload);
+        let response = handler.invoke(request).await.expect("handler failed");
+        assert!(response.subscribed);
+        assert_eq!(
+            response.subscription,
+            Some(Subscription {
+                expires_at: timestamp
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn request_expired() {
+        let mut handler = Handler::default();
+        let key = SecretKey::random(&mut rand::thread_rng());
+        let now = Utc::now();
+        handler
+            .builder
+            .time_service
+            .expect_current_time()
+            .returning(move || now);
+
+        let payload = Payload {
+            nonce: rand::random(),
+            expires_at: now - Duration::from_secs(60),
+        };
+        let request = SignedRequest::new(&key, &payload);
+        let err = handler.invoke(request).await.expect_err("handler failed");
+        assert!(matches!(err, HandlerError::PayloadExpired));
+    }
+}

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1,0 +1,107 @@
+use nillion_nucs::k256::ecdsa::signature::Verifier;
+use nillion_nucs::k256::ecdsa::{Signature, VerifyingKey};
+use nillion_nucs::k256::PublicKey;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub(crate) struct SignedRequest {
+    #[serde(with = "hex::serde")]
+    pub(crate) public_key: [u8; 33],
+
+    #[serde(with = "hex::serde")]
+    pub(crate) signature: [u8; 64],
+
+    #[serde(with = "hex::serde")]
+    pub(crate) payload: Vec<u8>,
+}
+
+impl SignedRequest {
+    #[cfg(test)]
+    pub(crate) fn new<T>(key: &nillion_nucs::k256::SecretKey, payload: &T) -> Self
+    where
+        T: serde::Serialize,
+    {
+        use crate::tests::PublicKeyExt;
+        use nillion_nucs::k256::ecdsa::{signature::Signer, SigningKey};
+
+        let payload = serde_json::to_string(&payload).expect("failed to serialize payload");
+        let signature: Signature = SigningKey::from(key.clone()).sign(payload.as_bytes());
+        let signature = signature.to_bytes().try_into().unwrap();
+        SignedRequest {
+            public_key: key.public_key().to_bytes(),
+            signature,
+            payload: payload.as_bytes().to_vec(),
+        }
+    }
+
+    pub(crate) fn verify(self) -> Result<PublicKey, VerificationError> {
+        use VerificationError::*;
+        let verifying_key =
+            VerifyingKey::from_sec1_bytes(&self.public_key).map_err(|_| InvalidPublicKey)?;
+        let signature =
+            Signature::from_bytes(&self.signature.into()).map_err(|_| InvalidSignature)?;
+        verifying_key
+            .verify(&self.payload, &signature)
+            .map_err(|_| SignatureVerification)?;
+        Ok(PublicKey::from(verifying_key))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum VerificationError {
+    #[error("invalid public key")]
+    InvalidPublicKey,
+
+    #[error("invalid signature")]
+    InvalidSignature,
+
+    #[error("signature verification failed")]
+    SignatureVerification,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nillion_nucs::k256::{
+        ecdsa::{signature::SignerMut, SigningKey},
+        SecretKey,
+    };
+
+    #[test]
+    fn valid_signature() {
+        let key = SecretKey::random(&mut rand::thread_rng());
+        let payload = rand::random::<[u8; 16]>().to_vec();
+        let signature: Signature = SigningKey::from(&key).sign(&payload);
+        let request = SignedRequest {
+            public_key: key
+                .public_key()
+                .to_sec1_bytes()
+                .as_ref()
+                .try_into()
+                .unwrap(),
+            signature: signature.to_bytes().into(),
+            payload,
+        };
+        let public_key = request.verify().expect("verification failed");
+        assert_eq!(public_key, key.public_key());
+    }
+
+    #[test]
+    fn invalid_signature() {
+        let signing_key = SecretKey::random(&mut rand::thread_rng());
+        let other_key = SecretKey::random(&mut rand::thread_rng());
+        let payload = rand::random::<[u8; 16]>().to_vec();
+        let signature: Signature = SigningKey::from(&signing_key).sign(&payload);
+        let request = SignedRequest {
+            public_key: other_key
+                .public_key()
+                .to_sec1_bytes()
+                .as_ref()
+                .try_into()
+                .unwrap(),
+            signature: signature.to_bytes().into(),
+            payload,
+        };
+        request.verify().expect_err("verification succeeded");
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,11 +21,12 @@ async fn pay_and_mint(nilauth: NilAuth) {
         )
         .await
         .expect("failed to pay subscription");
-    client
+    let subscription = client
         .subscription_status(&key)
         .await
-        .expect("failed to get subscription status")
-        .expect("no subscription information");
+        .expect("failed to get subscription status");
+    assert!(subscription.subscribed);
+    subscription.details.expect("no subscription information");
     let token = client
         .request_token(&key)
         .await
@@ -52,6 +53,19 @@ async fn pay_and_mint(nilauth: NilAuth) {
     let minimum_expiration_time =
         Utc::now() + nilauth.config.payments.subscriptions.length - Duration::from_secs(10);
     assert!(token.expires_at.expect("no expiration on token") > minimum_expiration_time);
+}
+
+#[rstest]
+#[tokio::test]
+async fn subscription_status_without_subscription(nilauth: NilAuth) {
+    let client = DefaultNilauthClient::new(nilauth.endpoint).expect("failed to build client");
+    let key = SecretKey::random(&mut rand::thread_rng());
+    let subscription = client
+        .subscription_status(&key)
+        .await
+        .expect("failed to get subscription status");
+    assert!(!subscription.subscribed);
+    assert!(subscription.details.is_none());
 }
 
 #[rstest]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,6 +21,11 @@ async fn pay_and_mint(nilauth: NilAuth) {
         )
         .await
         .expect("failed to pay subscription");
+    client
+        .subscription_status(&key)
+        .await
+        .expect("failed to get subscription status")
+        .expect("no subscription information");
     let token = client
         .request_token(&key)
         .await


### PR DESCRIPTION
This adds a subscription status endpoint as requested by @pablojhl. The request endpoint is the same as the mint token one, so all that code can be reused in clients.

For now all you get is a structure like:

```json
{
    "subscribed": true,
    "details": {
        "expires_at": 1743618588
    }
}
```

Where `subscribed` is the field that determines whether you're subscribed. The details will be set even if your subscription is expired so checking `details != None` is not a valid check.

We can add more fields as needed, this is just what we currently store in the subscriptions table.