### PR TITLE
feat: add a `renewable_at` attribute in subscription status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "nilauth-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=7d8aa9c96f681047107b11f45d2bffd1b95bcd19#7d8aa9c96f681047107b11f45d2bffd1b95bcd19"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=70573b1250b47c4fff70fa845dacd0c7219ff2da#70573b1250b47c4fff70fa845dacd0c7219ff2da"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "nillion-chain-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=7d8aa9c96f681047107b11f45d2bffd1b95bcd19#7d8aa9c96f681047107b11f45d2bffd1b95bcd19"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=70573b1250b47c4fff70fa845dacd0c7219ff2da#70573b1250b47c4fff70fa845dacd0c7219ff2da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2000,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "nillion-chain-transactions"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=7d8aa9c96f681047107b11f45d2bffd1b95bcd19#7d8aa9c96f681047107b11f45d2bffd1b95bcd19"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=70573b1250b47c4fff70fa845dacd0c7219ff2da#70573b1250b47c4fff70fa845dacd0c7219ff2da"
 dependencies = [
  "prost",
 ]
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "nillion-nucs"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=7d8aa9c96f681047107b11f45d2bffd1b95bcd19#7d8aa9c96f681047107b11f45d2bffd1b95bcd19"
+source = "git+https://github.com/NillionNetwork/nilvm?rev=70573b1250b47c4fff70fa845dacd0c7219ff2da#70573b1250b47c4fff70fa845dacd0c7219ff2da"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ convert_case = "0.8"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.14"
 metrics = "0.24"
-nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "7d8aa9c96f681047107b11f45d2bffd1b95bcd19" }
-nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "7d8aa9c96f681047107b11f45d2bffd1b95bcd19" }
-nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "7d8aa9c96f681047107b11f45d2bffd1b95bcd19" }
+nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "70573b1250b47c4fff70fa845dacd0c7219ff2da" }
+nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "70573b1250b47c4fff70fa845dacd0c7219ff2da" }
+nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "70573b1250b47c4fff70fa845dacd0c7219ff2da" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rust_decimal = "1.37"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/run.rs
+++ b/src/run.rs
@@ -44,6 +44,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             started_at: Utc::now(),
             subscription_cost: config.payments.subscriptions.dollar_cost,
             subscription_cost_slippage: config.payments.subscriptions.payment_slippage,
+            subscription_renewal_threshold: config.payments.subscriptions.renewal_threshold,
         },
         services,
         databases,

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use nillion_chain_client::tx::PaymentTransactionRetriever;
 use nillion_nucs::k256::SecretKey;
 use rust_decimal::Decimal;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 pub(crate) type SharedState = State<Arc<AppState>>;
 
@@ -57,4 +57,7 @@ pub struct Parameters {
 
     /// The allowed slippage in the range 0-1.
     pub subscription_cost_slippage: Decimal,
+
+    /// The threshold at which a subscription can be renewd.
+    pub subscription_renewal_threshold: Duration,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,6 +10,7 @@ use nillion_chain_client::tx::{PaymentTransaction, PaymentTransactionRetriever, 
 use nillion_nucs::k256::{PublicKey, SecretKey};
 use rust_decimal::Decimal;
 use std::sync::Arc;
+use std::time::Duration;
 
 mock! {
     pub(crate) PaymentRetriever {}
@@ -28,6 +29,7 @@ pub(crate) struct AppStateBuilder {
     pub(crate) account_db: MockAccountDb,
     pub(crate) revocation_db: MockRevocationDb,
     pub(crate) subscription_cost: Decimal,
+    pub(crate) subscription_renewal_threshold: Duration,
 }
 
 impl Default for AppStateBuilder {
@@ -40,6 +42,7 @@ impl Default for AppStateBuilder {
             account_db: Default::default(),
             revocation_db: Default::default(),
             subscription_cost: 1.into(),
+            subscription_renewal_threshold: Duration::from_secs(60),
         }
     }
 }
@@ -62,6 +65,7 @@ impl AppStateBuilder {
             account_db,
             revocation_db,
             subscription_cost,
+            subscription_renewal_threshold,
         } = self;
 
         Arc::new(AppState {
@@ -71,6 +75,7 @@ impl AppStateBuilder {
                 subscription_cost,
                 // 0.01
                 subscription_cost_slippage: Decimal::new(1, 2),
+                subscription_renewal_threshold,
             },
             services: Services {
                 tx: Box::new(tx_retriever),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,10 +15,7 @@ async fn pay_and_mint(nilauth: NilAuth) {
     let client = DefaultNilauthClient::new(nilauth.endpoint).expect("failed to build client");
     let key = SecretKey::random(&mut rand::thread_rng());
     client
-        .pay_subscription(
-            &mut *nilauth.nilchain_client.lock().await,
-            &key.public_key(),
-        )
+        .pay_subscription(&mut *nilauth.nilchain_client.lock().await, &key)
         .await
         .expect("failed to pay subscription");
     let subscription = client
@@ -89,25 +86,18 @@ async fn pay_too_soon(nilauth: NilAuth) {
     let client = DefaultNilauthClient::new(nilauth.endpoint).expect("failed to build client");
     let key = SecretKey::random(&mut rand::thread_rng());
     client
-        .pay_subscription(
-            &mut *nilauth.nilchain_client.lock().await,
-            &key.public_key(),
-        )
+        .pay_subscription(&mut *nilauth.nilchain_client.lock().await, &key)
         .await
         .expect("failed to pay subscription");
 
     // Pay again, this should fail because we just started our subscription
     let err = client
-        .pay_subscription(
-            &mut *nilauth.nilchain_client.lock().await,
-            &key.public_key(),
-        )
+        .pay_subscription(&mut *nilauth.nilchain_client.lock().await, &key)
         .await
         .expect_err("subscription payment succeeded");
-    let PaySubscriptionError::Request(err) = err else {
+    let PaySubscriptionError::CannotRenewYet(_) = err else {
         panic!("not a request error: {err}")
     };
-    assert_eq!(err.error_code, "CANNOT_RENEW_YET");
 }
 
 #[rstest]
@@ -116,10 +106,7 @@ async fn list_unrevoked(nilauth: NilAuth) {
     let client = DefaultNilauthClient::new(nilauth.endpoint).expect("failed to build client");
     let key = SecretKey::random(&mut rand::thread_rng());
     client
-        .pay_subscription(
-            &mut *nilauth.nilchain_client.lock().await,
-            &key.public_key(),
-        )
+        .pay_subscription(&mut *nilauth.nilchain_client.lock().await, &key)
         .await
         .expect("failed to pay subscription");
     let token = client.request_token(&key).await.expect("failed to mint");
@@ -137,10 +124,7 @@ async fn revoke(nilauth: NilAuth) {
     let client = DefaultNilauthClient::new(nilauth.endpoint).expect("failed to build client");
     let key = SecretKey::random(&mut rand::thread_rng());
     client
-        .pay_subscription(
-            &mut *nilauth.nilchain_client.lock().await,
-            &key.public_key(),
-        )
+        .pay_subscription(&mut *nilauth.nilchain_client.lock().await, &key)
         .await
         .expect("failed to pay subscription");
 


### PR DESCRIPTION
This adds a new `renewable_at` attribute in the subscription status endpoint so clients can check whether they should make the payment before doing so. Otherwise in its current state they can only pay and then get rejected by the server, losing the payment in the process.