### PR TITLE
chore: use public nuc-rs and nilauth-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,6 @@ dependencies = [
  "metrics",
  "mockall",
  "nilauth-client",
- "nillion-chain-client",
  "nillion-nucs",
  "rand 0.8.5",
  "reqwest 0.12.15",
@@ -1960,26 +1959,26 @@ dependencies = [
 [[package]]
 name = "nilauth-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935#8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935"
+source = "git+https://github.com/NillionNetwork/nilauth-client-rs?rev=7c5105d250e46d87dd4e3cdbdd0519a949f5186c#7c5105d250e46d87dd4e3cdbdd0519a949f5186c"
 dependencies = [
  "async-trait",
  "chrono",
  "hex",
- "nillion-chain-client",
+ "nilchain-client",
  "nillion-nucs",
  "rand 0.8.5",
  "reqwest 0.12.15",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "nillion-chain-client"
+name = "nilchain-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935#8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935"
+source = "git+https://github.com/NillionNetwork/nilchain-client-rs.git?rev=958674cd4d667632c469e2d210fb3b6e1867ab7c#958674cd4d667632c469e2d210fb3b6e1867ab7c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1987,7 +1986,6 @@ dependencies = [
  "cosmrs",
  "futures",
  "hex",
- "nillion-chain-transactions",
  "prost",
  "rand 0.8.5",
  "sha2 0.10.8",
@@ -1998,17 +1996,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "nillion-chain-transactions"
-version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935#8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935"
-dependencies = [
- "prost",
-]
-
-[[package]]
 name = "nillion-nucs"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilvm?rev=8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935#8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935"
+source = "git+https://github.com/NillionNetwork/nuc-rs?rev=687657acd08f2543e5c0d75e910eb9f1b1152d00#687657acd08f2543e5c0d75e910eb9f1b1152d00"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,8 @@ convert_case = "0.8"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.14"
 metrics = "0.24"
-nilauth-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935" }
-nillion-nucs = { git = "https://github.com/NillionNetwork/nilvm", rev = "8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935" }
-nillion-chain-client = { git = "https://github.com/NillionNetwork/nilvm", rev = "8d8d0d5846e1f8ad4c5b6f9926bbfb561e488935" }
+nilauth-client = { git = "https://github.com/NillionNetwork/nilauth-client-rs", rev = "7c5105d250e46d87dd4e3cdbdd0519a949f5186c" }
+nillion-nucs = { git = "https://github.com/NillionNetwork/nuc-rs", rev = "687657acd08f2543e5c0d75e910eb9f1b1152d00" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rust_decimal = "1.37"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -52,7 +52,7 @@ where
         };
         let token = state
             .validator
-            .validate(token, parameters)
+            .validate(token, parameters, &Default::default())
             .map_err(|e| make_unauthorized(format!("invalid token: {e}")))?;
         Ok(Self(token))
     }

--- a/src/routes/payments/validate.rs
+++ b/src/routes/payments/validate.rs
@@ -6,7 +6,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use metrics::counter;
-use nillion_chain_client::tx::RetrieveError;
+use nilauth_client::nilchain_client::tx::RetrieveError;
 use nillion_nucs::k256::{
     sha2::{Digest, Sha256},
     PublicKey,
@@ -195,7 +195,7 @@ mod tests {
     use crate::tests::{random_public_key, AppStateBuilder, PublicKeyExt};
     use axum::extract::State;
     use mockall::predicate::eq;
-    use nillion_chain_client::{transactions::TokenAmount, tx::PaymentTransaction};
+    use nilauth_client::nilchain_client::{transactions::TokenAmount, tx::PaymentTransaction};
     use nillion_nucs::k256::SecretKey;
 
     #[derive(Default)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -11,7 +11,7 @@ use axum_prometheus::{
     metrics_exporter_prometheus::PrometheusBuilder, EndpointLabel, PrometheusMetricLayerBuilder,
 };
 use chrono::Utc;
-use nillion_chain_client::tx::DefaultPaymentTransactionRetriever;
+use nilauth_client::nilchain_client::tx::DefaultPaymentTransactionRetriever;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::signal;

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use axum::extract::State;
 use chrono::{DateTime, Utc};
-use nillion_chain_client::tx::PaymentTransactionRetriever;
+use nilauth_client::nilchain_client::tx::PaymentTransactionRetriever;
 use nillion_nucs::k256::SecretKey;
 use rust_decimal::Decimal;
 use std::{sync::Arc, time::Duration};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,7 +6,9 @@ use crate::time::MockTimeService;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mockall::mock;
-use nillion_chain_client::tx::{PaymentTransaction, PaymentTransactionRetriever, RetrieveError};
+use nilauth_client::nilchain_client::tx::{
+    PaymentTransaction, PaymentTransactionRetriever, RetrieveError,
+};
 use nillion_nucs::k256::{PublicKey, SecretKey};
 use rust_decimal::Decimal;
 use std::sync::Arc;

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -3,7 +3,7 @@ use axum::http::StatusCode;
 use axum::routing::get;
 use axum::Router;
 use axum::{extract::Query, Json};
-use nillion_chain_client::{client::NillionChainClient, key::NillionChainPrivateKey};
+use nilauth_client::nilchain_client::{client::NillionChainClient, key::NillionChainPrivateKey};
 use rstest::fixture;
 use serde::Deserialize;
 use serde_json::json;


### PR DESCRIPTION
This uses the new repos for nuc-rs and nilauth-client instead of the ones inside nilvm, which will be removed soon. This also stops depending directly on nillion-chain-client since there's a new re-export in nilauth-client for it.