### PR TITLE
feat: allow CORS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,6 +1952,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror 2.0.12",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "time", "signal"] }
+tower-http = { version = "0.6", features = ["cors"] }
 
 [dev-dependencies]
 libc = "0.2"


### PR DESCRIPTION
This enables CORS so we can use nilauth via nuc-ts in the browser.

Closes #35