### PR TITLE
feat: expose openapi docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,6 +1955,8 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-axum",
 ]
 
 [[package]]
@@ -4223,6 +4225,43 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
+dependencies = [
+ "indexmap 2.7.1",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.99",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "time", "signal"] }
 tower-http = { version = "0.6", features = ["cors"] }
+utoipa = { version = "5.3.1", features = ["chrono", "axum_extras"] }
+utoipa-axum = "0.2.0"
 
 [dev-dependencies]
 libc = "0.2"

--- a/src/db/revocations.rs
+++ b/src/db/revocations.rs
@@ -6,6 +6,7 @@ use nillion_nucs::token::ProofHash;
 use serde::Serialize;
 use sqlx::prelude::FromRow;
 use tracing::error;
+use utoipa::ToSchema;
 
 /// A revocations database.
 #[cfg_attr(test, mockall::automock)]
@@ -132,12 +133,14 @@ impl RevocationDb for PostgresRevocationDb {
 }
 
 /// A revoked token.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, ToSchema)]
 pub(crate) struct RevokedToken {
     /// The token hash.
     #[serde(with = "hex::serde")]
+    #[schema(value_type = String, examples(crate::docs::proof_hash))]
     pub(crate) token_hash: Vec<u8>,
 
     /// The timestamp at which the token was revoked.
+    #[schema(value_type = u64)]
     pub(crate) revoked_at: DateTime<Utc>,
 }

--- a/src/db/subscriptions.rs
+++ b/src/db/subscriptions.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{prelude::FromRow, query, query_as, Executor, Postgres};
 use std::{fmt, ops::DerefMut};
 use tracing::{error, info};
+use utoipa::ToSchema;
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
@@ -29,7 +30,7 @@ pub(crate) trait SubscriptionDb: Send + Sync + 'static {
         -> sqlx::Result<()>;
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum BlindModule {
     NilAi,

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -1,0 +1,31 @@
+pub(crate) fn public_key() -> &'static str {
+    "02b482d7f1b9676e0cdd3ecf287ffadd5493d371daeb15e89dd38661ab3588fdbc"
+}
+
+pub(crate) fn hex_payload() -> &'static str {
+    "4ebbe4543703f175bfe0c5f365a9159109be25923e23cad9a2a468ab92c75b0d"
+}
+
+pub(crate) fn signature() -> &'static str {
+    "71d0952450911f304a49c1da7d763c4d58c8ac95cc52d172eb24566e19319172155a5e2fac70ab7973ca84fbe50dcf2cbe62c7d6f1b0c91ca07fb349877565d2"
+}
+
+pub(crate) fn nonce() -> &'static str {
+    "357f31164cc5822a9745e1c49aec209d"
+}
+
+pub(crate) fn nuc() -> &'static str {
+    "eyJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6bmlsOjAyMjZhNGQ0YTRhNWZhZGUxMmM1ZmYwZWM5YzQ3MjQ5ZjIxY2Y3N2EyMDI3NTFmOTU5ZDVjNzc4ZjBiNjUyYjcxNiIsImF1ZCI6ImRpZDpuaWw6YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwic3ViIjoiZGlkOm5pbDpjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MiLCJjbWQiOiIvbmlsL2RiL3JlYWQiLCJhcmdzIjp7ImZvbyI6NDJ9LCJub25jZSI6IjAxMDIwMyIsInByZiI6WyJjOTA0YzVhMWFiMzY5YWVhMWI0ZDlkMTkwMmE0NmU2ZWY5NGFhYjk2OTY0YmI1MWQ2MWE2MWIwM2UyM2Q1ZGZmIl19.ufDYxqoSVNVETrVKReu0h_Piul5c6RoC_VnGGLw04mkyn2OMrtQjK92sGXNHCjlp7T9prIwxX14ZB_N3gx7hPg"
+}
+
+pub(crate) fn proof_hash() -> &'static str {
+    "5bdb6de5f5a3d9c582973f3b53e263e23c98c0a0c7365a70c7aa02e7fa945a1a"
+}
+
+pub(crate) fn blind_module() -> &'static str {
+    "nildb"
+}
+
+pub(crate) fn epoch_timestamp() -> u64 {
+    1750098480
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod run;
 mod auth;
 mod cleanup;
 mod db;
+mod docs;
 mod routes;
 mod services;
 mod signed;

--- a/src/routes/about.rs
+++ b/src/routes/about.rs
@@ -2,10 +2,12 @@ use crate::state::SharedState;
 use axum::Json;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub(crate) struct About {
     #[serde(with = "hex::serde")]
+    #[schema(value_type = String, examples(crate::docs::public_key))]
     public_key: Box<[u8]>,
 
     build: BuildInfo,
@@ -13,12 +15,15 @@ pub(crate) struct About {
     started: DateTime<Utc>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 struct BuildInfo {
+    #[schema(examples("ff0d9198d1b8819527bc036a58f875c4046b6f21"))]
     commit: String,
     timestamp: DateTime<Utc>,
 }
 
+/// Get general information about this nilauth instance.
+#[utoipa::path(get, path = "/about", responses((status = OK, body = About, description = "Information about this nilauth instance")))]
 pub(crate) async fn handler(state: SharedState) -> Json<About> {
     let build_timestamp = env!("BUILD_TIMESTAMP").parse().unwrap_or(0);
     let build_timestamp = DateTime::from_timestamp(build_timestamp, 0).unwrap_or_default();

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,6 +1,12 @@
 use axum::response::{IntoResponse, Response};
 use reqwest::StatusCode;
 
+/// Check the health of this service.
+#[utoipa::path(
+    get,
+    path = "/health",
+    responses((status = OK, body = String, description = "A string `OK` if the service is up and running", example = "OK"))
+)]
 pub(crate) async fn handler() -> Response {
     (StatusCode::OK, "OK").into_response()
 }

--- a/src/routes/payments/cost.rs
+++ b/src/routes/payments/cost.rs
@@ -6,20 +6,33 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 use strum::EnumDiscriminants;
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Serialize)]
-pub(crate) struct GetCostResponse {
-    /// The cost in unils.
-    pub(crate) cost_unils: u64,
-}
-
-#[derive(Deserialize)]
-pub(crate) struct RequestQuery {
+/// A request to get the cost for a subscription.
+#[derive(Deserialize, IntoParams)]
+pub(crate) struct GetCostArgs {
+    /// The blind module to get the cost for.
+    #[param(value_type = String, example = crate::docs::blind_module)]
     blind_module: BlindModule,
 }
 
+/// The response to a request to get a subscription cost.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct GetCostResponse {
+    /// The cost in unils.
+    #[schema(examples(1_000))]
+    cost_unils: u64,
+}
+
+/// Get the cost of a nilauth subscription.
+#[utoipa::path(
+    get,
+    path = "/payments/cost",
+    params(GetCostArgs),
+    responses((status = OK, body = GetCostResponse))
+)]
 pub(crate) async fn handler(
-    path: Query<RequestQuery>,
+    path: Query<GetCostArgs>,
     state: SharedState,
 ) -> Result<Json<GetCostResponse>, HandlerError> {
     let result = state

--- a/src/routes/revocations/lookup.rs
+++ b/src/routes/revocations/lookup.rs
@@ -7,17 +7,32 @@ use nillion_nucs::token::ProofHash;
 use nillion_nucs::validator::ValidationParameters;
 use serde::{Deserialize, Serialize};
 use strum::EnumDiscriminants;
+use utoipa::ToSchema;
 
-#[derive(Deserialize)]
+/// A request to check whether a token is revoked.
+#[derive(Deserialize, ToSchema)]
 pub(crate) struct LookupRevocationRequest {
+    /// The proof chain in the revocation being checked.
+    #[schema(value_type = Vec<String>, examples(crate::docs::proof_hash))]
     hashes: Vec<ProofHash>,
 }
 
-#[derive(Serialize)]
+/// The response to a request to look up a revocation.
+#[derive(Serialize, ToSchema)]
 pub(crate) struct LookupRevocationResponse {
+    /// The details of the tokens in the proof chain that were revoked.
     revoked: Vec<RevokedToken>,
 }
 
+/// Lookup a revoked token.
+#[utoipa::path(
+    post,
+    path = "/revocations/lookup",
+    responses(
+        (status = OK, body = LookupRevocationResponse, description = "The tokens in the proof chain that have been revoked"),
+        (status = 400, body = RequestHandlerError),
+    )
+)]
 pub(crate) async fn handler(
     state: SharedState,
     Json(request): Json<LookupRevocationRequest>,

--- a/src/routes/revocations/revoke.rs
+++ b/src/routes/revocations/revoke.rs
@@ -18,6 +18,15 @@ use tracing::info;
 const TOKEN_ARG: &str = "token";
 static REVOCATION_CMD: LazyLock<Command> = LazyLock::new(|| ["nuc", "revoke"].into());
 
+/// Revoke a token.
+#[utoipa::path(
+    post,
+    path = "/revocations/revoke",
+    responses(
+        (status = OK, body = ()),
+        (status = 400, body = RequestHandlerError),
+    )
+)]
 pub(crate) async fn handler(state: SharedState, auth: NucAuth) -> Result<Json<()>, HandlerError> {
     if auth.0.token.command != *REVOCATION_CMD {
         return Err(HandlerError::InvalidCommand);

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -2,16 +2,23 @@ use nillion_nucs::k256::ecdsa::signature::Verifier;
 use nillion_nucs::k256::ecdsa::{Signature, VerifyingKey};
 use nillion_nucs::k256::PublicKey;
 use serde::Deserialize;
+use utoipa::ToSchema;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema)]
 pub(crate) struct SignedRequest {
+    //// The public key for the keypair that signed this request, in hex form.
     #[serde(with = "hex::serde")]
+    #[schema(value_type = String, examples(crate::docs::public_key))]
     pub(crate) public_key: [u8; 33],
 
+    //// The request signature, in hex form.
     #[serde(with = "hex::serde")]
+    #[schema(value_type = String, examples(crate::docs::signature))]
     pub(crate) signature: [u8; 64],
 
+    /// The payload
     #[serde(with = "hex::serde")]
+    #[schema(value_type = String, examples(crate::docs::hex_payload))]
     pub(crate) payload: Vec<u8>,
 }
 


### PR DESCRIPTION
This adds an `/openapi.json` endpoint that returns the docs for the API in openapi format. There's more to be done on docs so they're a bit better in various places but this sets up a working base that we can iterate on.