### PR TITLE
chore!: expose revoked token timestamp as epoch timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "nilauth-client"
 version = "0.1.0"
-source = "git+https://github.com/NillionNetwork/nilauth-client-rs?rev=61e69801ec00902be38beacbaebd1a0371bccb11#61e69801ec00902be38beacbaebd1a0371bccb11"
+source = "git+https://github.com/NillionNetwork/nilauth-client-rs?rev=03519695b7e2741f7db4c4d7daa99bf00e3f59ce#03519695b7e2741f7db4c4d7daa99bf00e3f59ce"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ convert_case = "0.8"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.14"
 metrics = "0.24"
-nilauth-client = { git = "https://github.com/NillionNetwork/nilauth-client-rs", rev = "61e69801ec00902be38beacbaebd1a0371bccb11" }
+nilauth-client = { git = "https://github.com/NillionNetwork/nilauth-client-rs", rev = "03519695b7e2741f7db4c4d7daa99bf00e3f59ce" }
 nillion-nucs = { git = "https://github.com/NillionNetwork/nuc-rs", rev = "687657acd08f2543e5c0d75e910eb9f1b1152d00" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rust_decimal = "1.37"

--- a/src/db/revocations.rs
+++ b/src/db/revocations.rs
@@ -141,6 +141,7 @@ pub(crate) struct RevokedToken {
     pub(crate) token_hash: Vec<u8>,
 
     /// The timestamp at which the token was revoked.
-    #[schema(value_type = u64)]
+    #[serde(with = "chrono::serde::ts_seconds")]
+    #[schema(value_type = u64, examples(crate::docs::epoch_timestamp))]
     pub(crate) revoked_at: DateTime<Utc>,
 }


### PR DESCRIPTION
This changes the `/revocations/lookup` endpoint so the timestamp is an epoch timestamp instead of an ISO formatted datetime.