### PR TITLE
feat: expose process metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +990,16 @@ dependencies = [
  "libc",
  "libredox",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1772,6 +1791,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
@@ -1940,6 +1965,7 @@ dependencies = [
  "mockall",
  "nilauth-client",
  "nillion-nucs",
+ "procfs",
  "rand 0.8.5",
  "reqwest 0.12.15",
  "rstest",
@@ -2327,6 +2353,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.9.0",
+ "chrono",
+ "flate2",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.9.0",
+ "chrono",
+ "hex",
 ]
 
 [[package]]
@@ -2849,6 +2900,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
@@ -2856,7 +2920,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -3689,7 +3753,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -4774,7 +4838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.14"
 metrics = "0.24"
 nilauth-client = { git = "https://github.com/NillionNetwork/nilauth-client-rs", rev = "03519695b7e2741f7db4c4d7daa99bf00e3f59ce" }
 nillion-nucs = { git = "https://github.com/NillionNetwork/nuc-rs", rev = "687657acd08f2543e5c0d75e910eb9f1b1152d00" }
+procfs = "0.17"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rust_decimal = "1.37"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod auth;
 mod cleanup;
 mod db;
 mod docs;
+mod metrics;
 mod routes;
 mod services;
 mod signed;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,77 @@
+//! Collector for process metrics.
+
+use metrics::{counter, gauge};
+use procfs::{net::TcpState, process::Process, WithCurrentSystemInfo};
+use std::{sync::LazyLock, time::Duration};
+use tokio::time::sleep;
+use tracing::warn;
+
+static TICKS_PER_SECOND: LazyLock<f64> = LazyLock::new(|| procfs::ticks_per_second() as f64);
+const COLLECT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Metrics about the node process.
+pub struct ProcessMetricsCollector;
+
+impl ProcessMetricsCollector {
+    /// Run the process metrics collector.
+    pub fn spawn() {
+        tokio::spawn(async move {
+            loop {
+                Self::collect_metrics();
+                sleep(COLLECT_INTERVAL).await;
+            }
+        });
+    }
+
+    fn collect_metrics() {
+        let metrics = match Process::myself() {
+            Ok(metrics) => metrics,
+            Err(e) => {
+                warn!("Failed to load procfs entry: {e}");
+                return;
+            }
+        };
+        let stat = match metrics.stat() {
+            Ok(stat) => stat,
+            Err(e) => {
+                warn!("Failed to load procfs stat: {e}");
+                return;
+            }
+        };
+        let tick_rate = *TICKS_PER_SECOND;
+        match stat.utime.checked_add(stat.stime) {
+            Some(total_ticks) => {
+                let total_milliseconds = (total_ticks as f64 / tick_rate) * 1000.0;
+                counter!("process_cpu_milliseconds_total").absolute(total_milliseconds as u64);
+            }
+            None => warn!("CPU time calculation overflowed"),
+        };
+        let rss = stat.rss_bytes().get() as f64;
+        gauge!("process_resident_memory_bytes").set(rss);
+
+        if let Some(count) = metrics.fd_count().ok().and_then(|c| i32::try_from(c).ok()) {
+            gauge!("open_file_descriptors").set(count);
+        }
+        gauge!("process_threads").set(stat.num_threads as f64);
+
+        if let Ok(io) = metrics.io() {
+            let operation_values = [
+                ("read", io.read_bytes, io.syscr),
+                ("write", io.write_bytes, io.syscw),
+            ];
+            for (operation, bytes, syscalls) in operation_values {
+                // See notes on gauge vs counter semantics needed for CPU time.
+                counter!("storage_io_bytes_total", "operation" => operation).absolute(bytes);
+                counter!("storage_io_syscalls_total", "operation" => operation).absolute(syscalls);
+            }
+        }
+
+        if let Ok(net) = metrics.tcp() {
+            let established_count = net
+                .iter()
+                .filter(|connection| connection.state == TcpState::Established)
+                .count() as f64;
+            gauge!("established_tcp_connections").set(established_count);
+        }
+    }
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -2,6 +2,7 @@ use crate::cleanup::RevokedTokenCleaner;
 use crate::config::Config;
 use crate::db::revocations::PostgresRevocationDb;
 use crate::db::{subscriptions::PostgresSubscriptionDb, PostgresPool};
+use crate::metrics::ProcessMetricsCollector;
 use crate::services::subscription_cost::DefaultSubscriptionCostService;
 use crate::services::token_price::CoinGeckoTokenPriceService;
 use crate::state::{AppState, Databases, Parameters, Services};
@@ -84,6 +85,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         .layer(cors);
     let metrics_router =
         Router::new().route("/metrics", get(|| async move { metrics_handle.render() }));
+
+    ProcessMetricsCollector::spawn();
 
     let app = serve(config.server.bind_endpoint, router, "main");
     let metrics = serve(config.metrics.bind_endpoint, metrics_router, "metrics");


### PR DESCRIPTION
This exposes process metrics so we can know cpu/memory/io usage. I also added a `module` parameter in a couple of metrics where we want to know the blind module being interacted with.