### PR TITLE
fix: lowercase tx hash before storing it

### DIFF
--- a/src/routes/payments/validate.rs
+++ b/src/routes/payments/validate.rs
@@ -75,7 +75,7 @@ pub(crate) async fn handler(
     }
 
     // Make sure the client has proven they made the transaction
-    let tx_hash = request.tx_hash;
+    let tx_hash = request.tx_hash.to_lowercase();
     let tx = state.services.tx.get(&tx_hash).await?;
     let payload_hash = Sha256::digest(&request.payload);
     if tx.resource != payload_hash.as_slice() {


### PR DESCRIPTION
This lowercases the tx hash before doing anything with it as otherwise you can submit the same transaction hash, sometimes using lowercase, sometimes uppercase, and it will go through.